### PR TITLE
Expose SignatureSchemes in ClientHelloInfo

### DIFF
--- a/common.go
+++ b/common.go
@@ -147,16 +147,16 @@ const (
 	signatureECDSA uint8 = 3
 )
 
-// signatureAndHash mirrors the TLS 1.2, SignatureAndHashAlgorithm struct. See
+// SignatureAndHash mirrors the TLS 1.2, SignatureAndHashAlgorithm struct. See
 // RFC 5246, section A.4.1.
-type signatureAndHash struct {
+type SignatureAndHash struct {
 	hash, signature uint8
 }
 
 // supportedSignatureAlgorithms contains the signature and hash algorithms that
 // the code advertises as supported in a TLS 1.2 ClientHello and in a TLS 1.2
 // CertificateRequest.
-var supportedSignatureAlgorithms = []signatureAndHash{
+var supportedSignatureAlgorithms = []SignatureAndHash{
 	{hashSHA256, signatureRSA},
 	{hashSHA256, signatureECDSA},
 	{hashSHA384, signatureRSA},
@@ -248,6 +248,13 @@ type ClientHelloInfo struct {
 	// is being used (see
 	// http://tools.ietf.org/html/rfc4492#section-5.1.2).
 	SupportedPoints []uint8
+
+	// SignatureSchemes lists the client's supported signature and hash
+	// pairs for validating digital signatures.
+	// SignatureSchemes is set only if the Signature Algorithms extension
+	// is being used (see
+	// http://tools.ietf.org/html/rfc5246#section-7.4.1.4.1).
+	SignatureSchemes []SignatureAndHash
 }
 
 // RenegotiationSupport enumerates the different levels of support for TLS
@@ -759,7 +766,7 @@ func unexpectedMessageError(wanted, got interface{}) error {
 	return fmt.Errorf("tls: received unexpected handshake message of type %T when waiting for %T", got, wanted)
 }
 
-func isSupportedSignatureAndHash(sigHash signatureAndHash, sigHashes []signatureAndHash) bool {
+func isSupportedSignatureAndHash(sigHash SignatureAndHash, sigHashes []SignatureAndHash) bool {
 	for _, s := range sigHashes {
 		if s == sigHash {
 			return true

--- a/handshake_messages.go
+++ b/handshake_messages.go
@@ -21,7 +21,7 @@ type clientHelloMsg struct {
 	supportedPoints              []uint8
 	ticketSupported              bool
 	sessionTicket                []uint8
-	signatureAndHashes           []signatureAndHash
+	signatureAndHashes           []SignatureAndHash
 	secureRenegotiation          []byte
 	secureRenegotiationSupported bool
 	alpnProtocols                []string
@@ -450,7 +450,7 @@ func (m *clientHelloMsg) unmarshal(data []byte) bool {
 			}
 			n := l / 2
 			d := data[2:]
-			m.signatureAndHashes = make([]signatureAndHash, n)
+			m.signatureAndHashes = make([]SignatureAndHash, n)
 			for i := range m.signatureAndHashes {
 				m.signatureAndHashes[i].hash = d[0]
 				m.signatureAndHashes[i].signature = d[1]
@@ -1302,7 +1302,7 @@ type certificateRequestMsg struct {
 	hasSignatureAndHash bool
 
 	certificateTypes       []byte
-	signatureAndHashes     []signatureAndHash
+	signatureAndHashes     []SignatureAndHash
 	certificateAuthorities [][]byte
 }
 
@@ -1411,7 +1411,7 @@ func (m *certificateRequestMsg) unmarshal(data []byte) bool {
 			return false
 		}
 		numSigAndHash := sigAndHashLen / 2
-		m.signatureAndHashes = make([]signatureAndHash, numSigAndHash)
+		m.signatureAndHashes = make([]SignatureAndHash, numSigAndHash)
 		for i := range m.signatureAndHashes {
 			m.signatureAndHashes[i].hash = data[0]
 			m.signatureAndHashes[i].signature = data[1]
@@ -1453,7 +1453,7 @@ func (m *certificateRequestMsg) unmarshal(data []byte) bool {
 type certificateVerifyMsg struct {
 	raw                 []byte
 	hasSignatureAndHash bool
-	signatureAndHash    signatureAndHash
+	signatureAndHash    SignatureAndHash
 	signature           []byte
 }
 
@@ -1652,7 +1652,7 @@ func eqByteSlices(x, y [][]byte) bool {
 	return true
 }
 
-func eqSignatureAndHashes(x, y []signatureAndHash) bool {
+func eqSignatureAndHashes(x, y []SignatureAndHash) bool {
 	if len(x) != len(y) {
 		return false
 	}

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -229,11 +229,12 @@ Curves:
 	}
 
 	hs.cert, err = config.getCertificate(&ClientHelloInfo{
-		CipherSuites:    hs.clientHello.cipherSuites,
-		ServerName:      hs.clientHello.serverName,
-		SupportedCurves: hs.clientHello.supportedCurves,
-		SupportedPoints: hs.clientHello.supportedPoints,
-		// TODO(filippo): add signatureAndHashes, version
+		CipherSuites:     hs.clientHello.cipherSuites,
+		ServerName:       hs.clientHello.serverName,
+		SupportedCurves:  hs.clientHello.supportedCurves,
+		SupportedPoints:  hs.clientHello.supportedPoints,
+		SignatureSchemes: hs.clientHello.signatureAndHashes,
+		// TODO(filippo): add version
 	})
 	if err != nil {
 		c.sendAlert(alertInternalError)
@@ -539,7 +540,7 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 		}
 
 		// Determine the signature type.
-		var signatureAndHash signatureAndHash
+		var signatureAndHash SignatureAndHash
 		if certVerify.hasSignatureAndHash {
 			signatureAndHash = certVerify.signatureAndHash
 			if !isSupportedSignatureAndHash(signatureAndHash, supportedSignatureAlgorithms) {

--- a/key_agreement.go
+++ b/key_agreement.go
@@ -110,7 +110,7 @@ func md5SHA1Hash(slices [][]byte) []byte {
 // hashForServerKeyExchange hashes the given slices and returns their digest
 // and the identifier of the hash function used. The sigAndHash argument is
 // only used for >= TLS 1.2 and precisely identifies the hash function to use.
-func hashForServerKeyExchange(sigAndHash signatureAndHash, version uint16, slices ...[]byte) ([]byte, crypto.Hash, error) {
+func hashForServerKeyExchange(sigAndHash SignatureAndHash, version uint16, slices ...[]byte) ([]byte, crypto.Hash, error) {
 	if version >= VersionTLS12 {
 		if !isSupportedSignatureAndHash(sigAndHash, supportedSignatureAlgorithms) {
 			return nil, crypto.Hash(0), errors.New("tls: unsupported hash function used by peer")
@@ -135,7 +135,7 @@ func hashForServerKeyExchange(sigAndHash signatureAndHash, version uint16, slice
 // pickTLS12HashForSignature returns a TLS 1.2 hash identifier for signing a
 // ServerKeyExchange given the signature type being used and the client's
 // advertised list of supported signature and hash combinations.
-func pickTLS12HashForSignature(sigType uint8, clientList []signatureAndHash) (uint8, error) {
+func pickTLS12HashForSignature(sigType uint8, clientList []SignatureAndHash) (uint8, error) {
 	if len(clientList) == 0 {
 		// If the client didn't specify any signature_algorithms
 		// extension then we can assume that it supports SHA1. See
@@ -220,7 +220,7 @@ NextCandidate:
 	serverECDHParams[3] = byte(len(ecdhePublic))
 	copy(serverECDHParams[4:], ecdhePublic)
 
-	sigAndHash := signatureAndHash{signature: ka.sigType}
+	sigAndHash := SignatureAndHash{signature: ka.sigType}
 
 	if ka.version >= VersionTLS12 {
 		if sigAndHash.hash, err = pickTLS12HashForSignature(ka.sigType, clientHello.signatureAndHashes); err != nil {
@@ -328,10 +328,10 @@ func (ka *ecdheKeyAgreement) processServerKeyExchange(config *Config, clientHell
 		return errServerKeyExchange
 	}
 
-	sigAndHash := signatureAndHash{signature: ka.sigType}
+	sigAndHash := SignatureAndHash{signature: ka.sigType}
 	if ka.version >= VersionTLS12 {
 		// handle SignatureAndHashAlgorithm
-		sigAndHash = signatureAndHash{hash: sig[0], signature: sig[1]}
+		sigAndHash = SignatureAndHash{hash: sig[0], signature: sig[1]}
 		if sigAndHash.signature != ka.sigType {
 			return errServerKeyExchange
 		}

--- a/prf.go
+++ b/prf.go
@@ -310,12 +310,12 @@ func (h finishedHash) serverSum(masterSecret []byte) []byte {
 	return out
 }
 
-// selectClientCertSignatureAlgorithm returns a signatureAndHash to sign a
+// selectClientCertSignatureAlgorithm returns a SignatureAndHash to sign a
 // client's CertificateVerify with, or an error if none can be found.
-func (h finishedHash) selectClientCertSignatureAlgorithm(serverList []signatureAndHash, sigType uint8) (signatureAndHash, error) {
+func (h finishedHash) selectClientCertSignatureAlgorithm(serverList []SignatureAndHash, sigType uint8) (SignatureAndHash, error) {
 	if h.version < VersionTLS12 {
 		// Nothing to negotiate before TLS 1.2.
-		return signatureAndHash{signature: sigType}, nil
+		return SignatureAndHash{signature: sigType}, nil
 	}
 
 	for _, v := range serverList {
@@ -323,12 +323,12 @@ func (h finishedHash) selectClientCertSignatureAlgorithm(serverList []signatureA
 			return v, nil
 		}
 	}
-	return signatureAndHash{}, errors.New("tls: no supported signature algorithm found for signing client certificate")
+	return SignatureAndHash{}, errors.New("tls: no supported signature algorithm found for signing client certificate")
 }
 
 // hashForClientCertificate returns a digest, hash function, and TLS 1.2 hash
 // id suitable for signing by a TLS client certificate.
-func (h finishedHash) hashForClientCertificate(signatureAndHash signatureAndHash, masterSecret []byte) ([]byte, crypto.Hash, error) {
+func (h finishedHash) hashForClientCertificate(signatureAndHash SignatureAndHash, masterSecret []byte) ([]byte, crypto.Hash, error) {
 	if (h.version == VersionSSL30 || h.version >= VersionTLS12) && h.buffer == nil {
 		panic("a handshake hash for a client-certificate was requested after discarding the handshake buffer")
 	}

--- a/tls13.go
+++ b/tls13.go
@@ -132,13 +132,13 @@ func (hs *serverHandshakeState) doTLS13Handshake() error {
 	// TODO(filippo): need a new, proper type for 1.3 SignatureScheme
 	// TODO(filippo): check what the client supports, add support for SHA384
 	var opts crypto.SignerOpts
-	sigType := signatureAndHash{hash: 0x04, signature: 0x03} // ecdsa_secp256r1_sha256
+	sigType := SignatureAndHash{hash: 0x04, signature: 0x03} // ecdsa_secp256r1_sha256
 	if hs.suite.flags&suiteECDSA == 0 {
 		// This is what we are supposed to use, but NSS if off-spec and mint goes with it.
 		//opts = &rsa.PSSOptions{SaltLength: sha256.Size, Hash: crypto.SHA256}
-		//sigType = signatureAndHash{hash: 0x07, signature: 0x00} // rsa_pss_sha256
+		//sigType = SignatureAndHash{hash: 0x07, signature: 0x00} // rsa_pss_sha256
 		opts = crypto.SHA256
-		sigType = signatureAndHash{hash: 0x04, signature: 0x01} // rsa_pkcs1_sha256
+		sigType = SignatureAndHash{hash: 0x04, signature: 0x01} // rsa_pkcs1_sha256
 	}
 
 	toSign := prepareDigitallySigned(sha256.New, "TLS 1.3, server CertificateVerify", hs.finishedHash.Sum())


### PR DESCRIPTION
Make the signatureAndHash structure public and expose client supported
signature and has pairs in ClientHelloInfo as SignatureSchemes for use
in certificate selection.