### PR TITLE
Fix Content-Type header for /ch endpoint

### DIFF
--- a/_dev/tris-localserver/server.go
+++ b/_dev/tris-localserver/server.go
@@ -85,7 +85,7 @@ func main() {
 	})
 
 	http.HandleFunc("/ch", func(w http.ResponseWriter, r *http.Request) {
-		r.Header.Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintf(w, "Client Hello packet (%d bytes):\n%s", len(r.TLS.ClientHello), hex.Dump(r.TLS.ClientHello))
 	})
 


### PR DESCRIPTION
It's a really minor thing that has no bearing on anything, but, for the sake of correctness, the `/ch` endpoint in tris-localserver sets the `Content-Type` header on the `*http.Request` rather than on the `http.ResponseWriter`.

This PR makes no other changes. I have signed the Google CLA for what it is worth.