### PR TITLE
Use unique ticket_age_add for each TLS 1.3 new ticket.

### DIFF
--- a/13.go
+++ b/13.go
@@ -566,15 +566,9 @@ func (hs *serverHandshakeState) sendSessionTicket13() error {
 	resumptionSecret := hkdfExpandLabel(hash, hs.masterSecret, handshakeCtx, "resumption master secret", hash.Size())
 
 	ageAddBuf := make([]byte, 4)
-	if _, err := io.ReadFull(c.config.rand(), ageAddBuf); err != nil {
-		c.sendAlert(alertInternalError)
-		return err
-	}
 	sessionState := &sessionState13{
-		vers:  c.vers,
-		suite: hs.suite.id,
-		ageAdd: uint32(ageAddBuf[0])<<24 | uint32(ageAddBuf[1])<<16 |
-			uint32(ageAddBuf[2])<<8 | uint32(ageAddBuf[3]),
+		vers:             c.vers,
+		suite:            hs.suite.id,
 		createdAt:        uint64(time.Now().Unix()),
 		resumptionSecret: resumptionSecret,
 		alpnProtocol:     c.clientProtocol,
@@ -583,6 +577,12 @@ func (hs *serverHandshakeState) sendSessionTicket13() error {
 	}
 
 	for i := 0; i < numSessionTickets; i++ {
+		if _, err := io.ReadFull(c.config.rand(), ageAddBuf); err != nil {
+			c.sendAlert(alertInternalError)
+			return err
+		}
+		sessionState.ageAdd = uint32(ageAddBuf[0])<<24 | uint32(ageAddBuf[1])<<16 |
+			uint32(ageAddBuf[2])<<8 | uint32(ageAddBuf[3])
 		ticket := sessionState.marshal()
 		var err error
 		if c.config.SessionTicketSealer != nil {


### PR DESCRIPTION
According to the specification, `ticket_age_add` should be unique per ticket. The current behaviour is to reuse the same value for each of the `numSessionTickets` issued ticket. This has been confirmed as a bug in tlswg/tls13-spec#913.

This change fixes this bug and does nothing else.