### PR TITLE
tris: prevent sending 0.5RTT data

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1256,6 +1256,12 @@ func (c *Conn) handlePostHandshake() error {
 	switch hm := msg.(type) {
 	case *helloRequestMsg:
 		return c.handleRenegotiation(hm)
+	case *newSessionTicketMsg13:
+		if !c.isClient {
+			c.sendAlert(alertUnexpectedMessage)
+			return alertUnexpectedMessage
+		}
+		return nil // TODO implement session tickets
 	default:
 		c.sendAlert(alertUnexpectedMessage)
 		return alertUnexpectedMessage

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -77,6 +77,16 @@ func (c *Conn) serverHandshake() error {
 			return err
 		}
 		c.hs = &hs
+		// If the client is sending early data while the server expects
+		// it, delay the Finished check until HandshakeConfirmed() is
+		// called or until all early data is Read(). Otherwise, complete
+		// authenticating the client now (there is no support for
+		// sending 0.5-RTT data to a potential unauthenticated client).
+		if c.phase != readingEarlyData {
+			if err := hs.readClientFinished13(false); err != nil {
+				return err
+			}
+		}
 		c.handshakeComplete = true
 		return nil
 	} else if isResume {


### PR DESCRIPTION
Three patches, two of them are needed to interop as client with servers that send session tickets (#50) and are included because of contextual conflicts. The final patch is:
___
tris: prevent sending 0.5-RTT data

Disable 0.5-RTT as it has weaker security properties than 1-RTT. The
same security considerations from TLS False Start (RFC 7918) apply.

Currently the server Handshake method returns as soon as it has sent its
parameters, but it does not wait for the client to authenticate the
handshake via a Finished message. This broke a test that assumed that
the Handshake message performs a full handshake and also
(unintentionally?) enabled the server to send application data before
the handshake is complete ("0.5-RTT data").

Fix this by moving the implicit Finished message check in the handshake
message reader to the server handshake itself (previously readRecord
would process the Finished message as a side-effect of requesting
recordTypeApplicationData). And in the special case where 0-RTT data is
actually desired, process the Finished message in the ConfirmHandshake
and Read functions.

NOTE: 0.5-RTT is not disabled when the server enables 0-RTT. It is the
server responsibility to use ConfirmHandshake before writing anything.

Explicitly panic when ConfirmHandshake is used for client connections,
this is not the intended use of that API.
