### PR TITLE
Refactor TLS 1.3 key schedule

### DIFF
--- a/common.go
+++ b/common.go
@@ -907,12 +907,12 @@ func (c *Config) BuildNameToCertificate() {
 
 // writeKeyLog logs client random and master secret if logging was enabled by
 // setting c.KeyLogWriter.
-func (c *Config) writeKeyLog(clientRandom, masterSecret []byte) error {
+func (c *Config) writeKeyLog(what string, clientRandom, masterSecret []byte) error {
 	if c.KeyLogWriter == nil {
 		return nil
 	}
 
-	logLine := []byte(fmt.Sprintf("CLIENT_RANDOM %x %x\n", clientRandom, masterSecret))
+	logLine := []byte(fmt.Sprintf("%s %x %x\n", what, clientRandom, masterSecret))
 
 	writerMutex.Lock()
 	_, err := c.KeyLogWriter.Write(logLine)

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -469,7 +469,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 	}
 
 	hs.masterSecret = masterFromPreMasterSecret(c.vers, hs.suite, preMasterSecret, hs.hello.random, hs.serverHello.random)
-	if err := c.config.writeKeyLog(hs.hello.random, hs.masterSecret); err != nil {
+	if err := c.config.writeKeyLog("CLIENT_RANDOM", hs.hello.random, hs.masterSecret); err != nil {
 		c.sendAlert(alertInternalError)
 		return errors.New("tls: failed to write to key log: " + err.Error())
 	}

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -573,7 +573,7 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 		return err
 	}
 	hs.masterSecret = masterFromPreMasterSecret(c.vers, hs.suite, preMasterSecret, hs.clientHello.random, hs.hello.random)
-	if err := c.config.writeKeyLog(hs.clientHello.random, hs.masterSecret); err != nil {
+	if err := c.config.writeKeyLog("CLIENT_RANDOM", hs.clientHello.random, hs.masterSecret); err != nil {
 		c.sendAlert(alertInternalError)
 		return err
 	}

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -13,7 +13,6 @@ import (
 	"encoding/asn1"
 	"errors"
 	"fmt"
-	"hash"
 	"io"
 	"sync/atomic"
 )
@@ -45,7 +44,7 @@ type serverHandshakeState struct {
 	// TLS 1.3 fields
 	hello13           *serverHelloMsg13
 	hello13Enc        *encryptedExtensionsMsg
-	finishedHash13    hash.Hash
+	keySchedule       *keySchedule13
 	clientFinishedKey []byte
 	hsClientCipher    interface{}
 	appClientCipher   interface{}


### PR DESCRIPTION
To enable code reuse with the TLS 1.3 client, support KeyLogWriter and prepare for supporting the label changes in draft -20, extract the current open-coded, interleaved key schedule functionality.
Hopefully the server handshake looks less complex now and easier to review for correctness.