### PR TITLE
Remove TLS13CipherSuites

### DIFF
--- a/cipher_suites.go
+++ b/cipher_suites.go
@@ -389,7 +389,7 @@ func mutualCipherSuite(have []uint16, want uint16) *cipherSuite {
 //
 // Taken from http://www.iana.org/assignments/tls-parameters/tls-parameters.xml
 const (
-	// TLS 1.0 - 1.2 cipher suites. To be used in Config.CipherSuites.
+	// TLS 1.0 - 1.2 cipher suites.
 	TLS_RSA_WITH_RC4_128_SHA                uint16 = 0x0005
 	TLS_RSA_WITH_3DES_EDE_CBC_SHA           uint16 = 0x000a
 	TLS_RSA_WITH_AES_128_CBC_SHA            uint16 = 0x002f
@@ -413,7 +413,7 @@ const (
 	TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305    uint16 = 0xcca8
 	TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305  uint16 = 0xcca9
 
-	// TLS 1.3+ cipher suites. To be used in Config.TLS13CipherSuites.
+	// TLS 1.3+ cipher suites.
 	TLS_AES_128_GCM_SHA256       uint16 = 0x1301
 	TLS_AES_256_GCM_SHA384       uint16 = 0x1302
 	TLS_CHACHA20_POLY1305_SHA256 uint16 = 0x1303

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -74,7 +74,7 @@ func (c *Conn) clientHandshake() error {
 		hello.secureRenegotiation = c.clientFinished[:]
 	}
 
-	possibleCipherSuites := c.config.cipherSuites(c.vers)
+	possibleCipherSuites := c.config.cipherSuites()
 	hello.cipherSuites = make([]uint16, 0, len(possibleCipherSuites))
 
 NextCipherSuite:

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -86,7 +86,12 @@ NextCipherSuite:
 			// Don't advertise TLS 1.2-only cipher suites unless
 			// we're attempting TLS 1.2.
 			if hello.vers < VersionTLS12 && suite.flags&suiteTLS12 != 0 {
-				continue
+				continue NextCipherSuite
+			}
+			// Don't advertise TLS 1.3-only cipher suites unless
+			// we're attempting TLS 1.3.
+			if hello.vers < VersionTLS13 && suite.flags&suiteTLS13 != 0 {
+				continue NextCipherSuite
 			}
 			hello.cipherSuites = append(hello.cipherSuites, suiteId)
 			continue NextCipherSuite

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -186,6 +186,12 @@ NextCipherSuite:
 		c.sendAlert(alertHandshakeFailure)
 		return errors.New("tls: server chose an unconfigured cipher suite")
 	}
+	// Check that the chosen cipher suite matches the protocol version.
+	if c.vers >= VersionTLS13 && suite.flags&suiteTLS13 == 0 ||
+		c.vers < VersionTLS13 && suite.flags&suiteTLS13 != 0 {
+		c.sendAlert(alertHandshakeFailure)
+		return errors.New("tls: server chose an inappropriate cipher suite")
+	}
 
 	hs := &clientHandshakeState{
 		c:            c,

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -322,11 +322,11 @@ Curves:
 
 	var preferenceList, supportedList []uint16
 	if c.config.PreferServerCipherSuites {
-		preferenceList = c.config.cipherSuites(c.vers)
+		preferenceList = c.config.cipherSuites()
 		supportedList = hs.clientHello.cipherSuites
 	} else {
 		preferenceList = hs.clientHello.cipherSuites
-		supportedList = c.config.cipherSuites(c.vers)
+		supportedList = c.config.cipherSuites()
 	}
 
 	for _, id := range preferenceList {
@@ -388,7 +388,7 @@ func (hs *serverHandshakeState) checkForResumption() bool {
 	}
 
 	// Check that we also support the ciphersuite from the session.
-	if !hs.setCipherSuite(hs.sessionState.cipherSuite, c.config.cipherSuites(c.vers), hs.sessionState.vers) {
+	if !hs.setCipherSuite(hs.sessionState.cipherSuite, c.config.cipherSuites(), hs.sessionState.vers) {
 		return false
 	}
 

--- a/handshake_server_test.go
+++ b/handshake_server_test.go
@@ -49,18 +49,6 @@ func allCipherSuites() []uint16 {
 	return ids
 }
 
-func allTLS13CipherSuites() []uint16 {
-	var ids []uint16
-	for _, suite := range cipherSuites {
-		if suite.flags&suiteTLS13 == 0 {
-			continue
-		}
-		ids = append(ids, suite.id)
-	}
-
-	return ids
-}
-
 func init() {
 	testConfig = &Config{
 		Time:               func() time.Time { return time.Unix(0, 0) },
@@ -70,7 +58,6 @@ func init() {
 		MinVersion:         VersionSSL30,
 		MaxVersion:         VersionTLS12,
 		CipherSuites:       allCipherSuites(),
-		TLS13CipherSuites:  allTLS13CipherSuites(),
 	}
 	testConfig.Certificates[0].Certificate = [][]byte{testRSACertificate}
 	testConfig.Certificates[0].PrivateKey = testRSAPrivateKey

--- a/tls_test.go
+++ b/tls_test.go
@@ -648,7 +648,6 @@ func TestCloneNonFuncFields(t *testing.T) {
 		case "SessionTicketKey":
 			f.Set(reflect.ValueOf([32]byte{}))
 		case "CipherSuites":
-		case "TLS13CipherSuites":
 			f.Set(reflect.ValueOf([]uint16{1, 2}))
 		case "CurvePreferences":
 			f.Set(reflect.ValueOf([]CurveID{CurveP256}))


### PR DESCRIPTION
As suggested in #22 by @tmthrgd , the TLS13CipherSuites option was removed.

The commit messages contain more details, but the main considerations for this choice are outlined here: https://github.com/cloudflare/tls-tris/pull/22#issuecomment-329286348

Summary of change: CipherSuites can be used to configure TLS 1.3 ciphers. If CipherSuites is overridden with TLS 1.2-only ciphers, but MaxVersion is 1.3, then the default TLS 1.3 ciphers will be prepended.