### PR TITLE
Disable TLS 1.3 by default, allow client to pick TLS 1.3

### DIFF
--- a/_dev/tris-localserver/server.go
+++ b/_dev/tris-localserver/server.go
@@ -41,6 +41,7 @@ func startServer(addr string, rsa, offer0RTT, accept0RTT bool) {
 				time.Sleep(500 * time.Millisecond)
 				return nil, nil
 			},
+			MaxVersion: tls.VersionTLS13,
 		},
 	}
 	log.Fatal(s.ListenAndServeTLS("", ""))

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -167,7 +167,7 @@ NextCipherSuite:
 		return unexpectedMessageError(serverHello, msg)
 	}
 
-	vers, ok := c.config.mutualVersion(serverHello.vers)
+	vers, ok := c.config.pickVersion([]uint16{serverHello.vers})
 	if !ok || vers < VersionTLS10 {
 		// TLS 1.0 is the minimum version supported as a client.
 		c.sendAlert(alertProtocolVersion)


### PR DESCRIPTION
Require applications to explicitly set `MaxVersion: tls.VersionTLS13` for now. Once full TLS 1.3 support is completed, the global MaxVersion can be bumped instead.

The version selection code is slightly adjusted to allow for sharing functionality between client and server.