### PR TITLE
tris: unify ServerHello processing in preparation for D22

### DIFF
--- a/13.go
+++ b/13.go
@@ -127,7 +127,7 @@ func (hs *serverHandshakeState) doTLS13Handshake() error {
 	config := hs.c.config
 	c := hs.c
 
-	hs.c.cipherSuite, hs.hello13.cipherSuite = hs.suite.id, hs.suite.id
+	hs.c.cipherSuite, hs.hello.cipherSuite = hs.suite.id, hs.suite.id
 	hs.c.clientHello = hs.clientHello.marshal()
 
 	// When picking the group for the handshake, priority is given to groups
@@ -159,7 +159,7 @@ CurvePreferenceLoop:
 		c.sendAlert(alertInternalError)
 		return err
 	}
-	hs.hello13.keyShare = serverKS
+	hs.hello.keyShare = serverKS
 
 	hash := hashForSuite(hs.suite)
 	hashSize := hash.Size()
@@ -188,8 +188,8 @@ CurvePreferenceLoop:
 		return errors.New("tls: bad ECDHE client share")
 	}
 
-	hs.keySchedule.write(hs.hello13.marshal())
-	if _, err := c.writeRecord(recordTypeHandshake, hs.hello13.marshal()); err != nil {
+	hs.keySchedule.write(hs.hello.marshal())
+	if _, err := c.writeRecord(recordTypeHandshake, hs.hello.marshal()); err != nil {
 		return err
 	}
 
@@ -603,8 +603,8 @@ func (hs *serverHandshakeState) checkPSK() (isResumed bool, alert alert) {
 				hs.hello13Enc.earlyData = true
 			}
 		}
-		hs.hello13.psk = true
-		hs.hello13.pskIdentity = uint16(i)
+		hs.hello.psk = true
+		hs.hello.pskIdentity = uint16(i)
 		return true, alertSuccess
 	}
 

--- a/common.go
+++ b/common.go
@@ -28,6 +28,7 @@ const (
 	VersionTLS12        = 0x0303
 	VersionTLS13        = 0x0304
 	VersionTLS13Draft18 = 0x7f00 | 18
+	VersionTLS13Draft21 = 0x7f00 | 21
 )
 
 const (

--- a/conn.go
+++ b/conn.go
@@ -1131,11 +1131,7 @@ func (c *Conn) readHandshake() (interface{}, error) {
 	case typeClientHello:
 		m = new(clientHelloMsg)
 	case typeServerHello:
-		if c.vers >= VersionTLS13 {
-			m = new(serverHelloMsg13)
-		} else {
-			m = new(serverHelloMsg)
-		}
+		m = new(serverHelloMsg)
 	case typeEncryptedExtensions:
 		m = new(encryptedExtensionsMsg)
 	case typeNewSessionTicket:

--- a/handshake_messages_test.go
+++ b/handshake_messages_test.go
@@ -26,7 +26,6 @@ var tests = []interface{}{
 	&nextProtoMsg{},
 	&newSessionTicketMsg{},
 	&sessionState{},
-	&serverHelloMsg13{},
 	&encryptedExtensionsMsg{},
 	&certificateMsg13{},
 	&newSessionTicketMsg13{},
@@ -209,16 +208,10 @@ func (*serverHelloMsg) Generate(rand *rand.Rand, size int) reflect.Value {
 		}
 	}
 
-	return reflect.ValueOf(m)
-}
-
-func (*serverHelloMsg13) Generate(rand *rand.Rand, size int) reflect.Value {
-	m := &serverHelloMsg13{}
-	m.vers = uint16(rand.Intn(65536))
-	m.random = randomBytes(32, rand)
-	m.cipherSuite = uint16(rand.Int31())
-	m.keyShare.group = CurveID(rand.Intn(30000))
-	m.keyShare.data = randomBytes(rand.Intn(300), rand)
+	if rand.Intn(10) > 5 {
+		m.keyShare.group = CurveID(rand.Intn(30000))
+		m.keyShare.data = randomBytes(rand.Intn(300), rand)
+	}
 	if rand.Intn(10) > 5 {
 		m.psk = true
 		m.pskIdentity = uint16(rand.Int31())

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -29,10 +29,10 @@ type serverHandshakeState struct {
 	masterSecret          []byte
 	cachedClientHelloInfo *ClientHelloInfo
 	clientHello           *clientHelloMsg
+	hello                 *serverHelloMsg
 	cert                  *Certificate
 
 	// TLS 1.0-1.2 fields
-	hello           *serverHelloMsg
 	ellipticOk      bool
 	ecdsaOk         bool
 	rsaDecryptOk    bool
@@ -42,7 +42,6 @@ type serverHandshakeState struct {
 	certsFromClient [][]byte
 
 	// TLS 1.3 fields
-	hello13           *serverHelloMsg13
 	hello13Enc        *encryptedExtensionsMsg
 	keySchedule       *keySchedule13
 	clientFinishedKey []byte
@@ -70,7 +69,7 @@ func (c *Conn) serverHandshake() error {
 	// For an overview of TLS handshaking, see https://tools.ietf.org/html/rfc5246#section-7.3
 	// and https://tools.ietf.org/html/draft-ietf-tls-tls13-18#section-2
 	c.buffering = true
-	if hs.hello13 != nil {
+	if c.vers >= VersionTLS13 {
 		if err := hs.doTLS13Handshake(); err != nil {
 			return err
 		}
@@ -250,11 +249,11 @@ Curves:
 		hs.hello.secureRenegotiationSupported = hs.clientHello.secureRenegotiationSupported
 		hs.hello.compressionMethod = compressionNone
 	} else {
-		hs.hello13 = new(serverHelloMsg13)
+		hs.hello = new(serverHelloMsg)
 		hs.hello13Enc = new(encryptedExtensionsMsg)
-		hs.hello13.vers = c.vers
-		hs.hello13.random = make([]byte, 32)
-		_, err = io.ReadFull(c.config.rand(), hs.hello13.random)
+		hs.hello.vers = c.vers
+		hs.hello.random = make([]byte, 32)
+		_, err = io.ReadFull(c.config.rand(), hs.hello.random)
 		if err != nil {
 			c.sendAlert(alertInternalError)
 			return false, err


### PR DESCRIPTION
Merge serverHelloMsg13 into serverHelloMsg in preparation for draft 22.
This will also simplify the client implementation since only one
structure has to be checked.

Also fixed potential out-of-bounds access with keyShare unmarshal.
___
Due to the issues mentioned in #52, I will not jump straight to D22, but neither do I want to redo all client changes two times either (once to adapt for the current master, once for D22 changes).

Therefore I made this refactoring change now (it is based off "tris: update Server Hello processing for D22" from the pwu/draft22 branch, but without D22 changes). After this, I should be able to update the client patches for D18 and work in parallel on D22 changes.