### PR TITLE
tris: fix nonce length definition and actually use it

### DIFF
--- a/13.go
+++ b/13.go
@@ -119,7 +119,7 @@ func (ks *keySchedule13) prepareCipher(secretLabel secretLabel) (interface{}, []
 	trafficSecret := ks.deriveSecret(secretLabel)
 	hash := hashForSuite(ks.suite)
 	key := hkdfExpandLabel(hash, trafficSecret, nil, "key", ks.suite.keyLen)
-	iv := hkdfExpandLabel(hash, trafficSecret, nil, "iv", 12)
+	iv := hkdfExpandLabel(hash, trafficSecret, nil, "iv", ks.suite.ivLen)
 	return ks.suite.aead(key, iv), trafficSecret
 }
 

--- a/cipher_suites.go
+++ b/cipher_suites.go
@@ -81,8 +81,8 @@ type cipherSuite struct {
 var cipherSuites = []*cipherSuite{
 	// TLS 1.3 ciphersuites specify only the AEAD and the HKDF hash.
 	{TLS_CHACHA20_POLY1305_SHA256, 32, 0, 12, nil, suiteTLS13, nil, nil, aeadChaCha20Poly1305},
-	{TLS_AES_128_GCM_SHA256, 16, 0, 4, nil, suiteTLS13, nil, nil, aeadAESGCM13},
-	{TLS_AES_256_GCM_SHA384, 32, 0, 4, nil, suiteTLS13 | suiteSHA384, nil, nil, aeadAESGCM13},
+	{TLS_AES_128_GCM_SHA256, 16, 0, 12, nil, suiteTLS13, nil, nil, aeadAESGCM13},
+	{TLS_AES_256_GCM_SHA384, 32, 0, 12, nil, suiteTLS13 | suiteSHA384, nil, nil, aeadAESGCM13},
 
 	// Ciphersuite order is chosen so that ECDHE comes before plain RSA and
 	// AEADs are the top preference.


### PR DESCRIPTION
All TLS 1.3 cipher suites so far use a nonce length of 12, but that does
not have to be the case. Correct the cipher suite definition and use it.
Spec: https://tools.ietf.org/html/draft-ietf-tls-tls13-22#section-5.3

Note: there is no functional change, the values were previously unused.

Fixes: ("[dev.tls] crypto/tls: implement TLS 1.3 cipher suites")
___
Reported in https://github.com/bifurcation/mint/issues/142