### PR TITLE
Draft 22 changes for the server and client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - MODE=interop CLIENT=boring SERVER=boring
   - MODE=interop CLIENT=tstclnt SERVER=tstclnt
   - MODE=interop CLIENT=picotls ZRTT=1
-  - MODE=interop CLIENT=mint
+# - MODE=interop CLIENT=mint    # does not support draft 22
   - MODE=bogo
   - MODE=gotest
   - MODE=interop CLIENT=tstclnt ZRTT=1
@@ -22,8 +22,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: MODE=interop CLIENT=boring REVISION=origin/master
-    - env: MODE=interop CLIENT=tstclnt REVISION=default ZRTT=1
-    - env: MODE=interop CLIENT=tstclnt ZRTT=1 # crashes on close_notify in 0.5RTT
 
 install:
   - if [ "$MODE" = "interop" ]; then ./_dev/tris-localserver/start.sh -d && docker ps -a; fi

--- a/_dev/bogo/Dockerfile
+++ b/_dev/bogo/Dockerfile
@@ -12,7 +12,13 @@ RUN git clone https://github.com/FiloSottile/crypto-tls-bogo-shim \
     /go/src/github.com/FiloSottile/crypto-tls-bogo-shim
 
 # Draft 18 with client-tests branch
-ARG REVISION=3f5e87d6a1931b6f6930e4eadb7b2d0b2aa7c588
+#ARG REVISION=3f5e87d6a1931b6f6930e4eadb7b2d0b2aa7c588
+
+# Draft 22 with draft22 branch
+#ARG REVISION=81cc32b846c9fe2ea32613287e57a6a0db7bbb9a
+
+# Draft 22 with draft22-client branch (client-tests + draft22)
+ARG REVISION=f9729b5e4eafb1f1d313949388c3c2b167e84734
 
 RUN cd /go/src/github.com/FiloSottile/crypto-tls-bogo-shim && \
     git checkout $REVISION

--- a/_dev/boring/Dockerfile
+++ b/_dev/boring/Dockerfile
@@ -38,6 +38,12 @@ RUN mkdir boringssl/build
 # Draft 18, but with "bssl server -loop -www" support and build fix
 ARG REVISION=40b24c8154
 
+# Draft 21
+#ARG REVISION=cd8470f
+
+# Draft 22
+ARG REVISION=1530ef3e
+
 RUN cd boringssl && git fetch
 RUN cd boringssl && git checkout $REVISION
 RUN cd boringssl/build && cmake -GNinja ..

--- a/_dev/boring/run.sh
+++ b/_dev/boring/run.sh
@@ -2,7 +2,7 @@
 set -e
 
 /boringssl/build/tool/bssl client -grease -min-version tls1.3 -max-version tls1.3 \
-	-session-out /session -connect "$@" < /httpreq.txt
+	-tls13-variant draft22 -session-out /session -connect "$@" < /httpreq.txt
 exec /boringssl/build/tool/bssl client -grease -min-version tls1.3 -max-version tls1.3 \
-	-session-in /session -connect "$@" < /httpreq.txt
+	-tls13-variant draft22 -session-in /session -connect "$@" < /httpreq.txt
 

--- a/_dev/boring/server.sh
+++ b/_dev/boring/server.sh
@@ -6,12 +6,14 @@ set -x
 bssl server \
     -key rsa.pem \
     -min-version tls1.2 -max-version tls1.3 \
+    -tls13-draft22-variant \
     -accept 1443 -loop -www 2>&1 &
 
 # ECDSA
 bssl server \
     -key ecdsa.pem \
     -min-version tls1.2 -max-version tls1.3 \
+    -tls13-draft22-variant \
     -accept 2443 -loop -www 2>&1 &
 
 wait

--- a/_dev/picotls/Dockerfile
+++ b/_dev/picotls/Dockerfile
@@ -10,7 +10,12 @@ RUN apk add --update \
 
 RUN git clone https://github.com/h2o/picotls
 
-ARG REVISION=a6c1c65
+# Draft -18
+#ARG REVISION=a6c1c65
+
+# Draft -22
+ARG REVISION=843ccdc
+
 RUN cd picotls && git fetch && git checkout $REVISION
 
 RUN cd picotls && git submodule update --init

--- a/_dev/tris-localserver/server.go
+++ b/_dev/tris-localserver/server.go
@@ -17,6 +17,7 @@ var tlsVersionToName = map[uint16]string{
 	tls.VersionTLS12:        "1.2",
 	tls.VersionTLS13:        "1.3",
 	tls.VersionTLS13Draft18: "1.3 (draft 18)",
+	tls.VersionTLS13Draft21: "1.3 (draft 21)",
 }
 
 func startServer(addr string, rsa, offer0RTT, accept0RTT bool) {

--- a/_dev/tris-localserver/server.go
+++ b/_dev/tris-localserver/server.go
@@ -18,6 +18,7 @@ var tlsVersionToName = map[uint16]string{
 	tls.VersionTLS13:        "1.3",
 	tls.VersionTLS13Draft18: "1.3 (draft 18)",
 	tls.VersionTLS13Draft21: "1.3 (draft 21)",
+	tls.VersionTLS13Draft22: "1.3 (draft 22)",
 }
 
 func startServer(addr string, rsa, offer0RTT, accept0RTT bool) {

--- a/_dev/tstclnt/Dockerfile
+++ b/_dev/tstclnt/Dockerfile
@@ -18,7 +18,10 @@ ENV USE_64=1 NSS_ENABLE_TLS_1_3=1
 # ARG REVISION=b6dfef6d0ff0
 
 # Draft 18, NSS_3_34_1_RTM (with TLS 1.3 keylogging support)
-ARG REVISION=e61c0f657100
+# ARG REVISION=e61c0f657100
+
+# Draft 22
+ARG REVISION=88c3f3fa581b
 
 RUN cd nss && hg pull
 RUN cd nss && hg checkout -C $REVISION

--- a/alert.go
+++ b/alert.go
@@ -16,7 +16,6 @@ const (
 
 const (
 	alertCloseNotify            alert = 0
-	alertEndOfEarlyData         alert = 1
 	alertUnexpectedMessage      alert = 10
 	alertBadRecordMAC           alert = 20
 	alertDecryptionFailed       alert = 21

--- a/common.go
+++ b/common.go
@@ -58,6 +58,7 @@ const (
 	typeClientHello         uint8 = 1
 	typeServerHello         uint8 = 2
 	typeNewSessionTicket    uint8 = 4
+	typeEndOfEarlyData      uint8 = 5
 	typeEncryptedExtensions uint8 = 8
 	typeCertificate         uint8 = 11
 	typeServerKeyExchange   uint8 = 12
@@ -90,7 +91,6 @@ const (
 	extensionEarlyData           uint16 = 42
 	extensionSupportedVersions   uint16 = 43
 	extensionPSKKeyExchangeModes uint16 = 45
-	extensionTicketEarlyDataInfo uint16 = 46
 	extensionNextProtoNeg        uint16 = 13172 // not IANA assigned
 	extensionRenegotiationInfo   uint16 = 0xff01
 )

--- a/common.go
+++ b/common.go
@@ -855,7 +855,7 @@ var configSuppVersArray = [...]uint16{VersionTLS13, VersionTLS12, VersionTLS11, 
 // with TLS 1.3 draft versions included.
 //
 // TODO: remove once TLS 1.3 is finalised.
-var tls13DraftSuppVersArray = [...]uint16{VersionTLS13Draft18, VersionTLS12, VersionTLS11, VersionTLS10, VersionSSL30}
+var tls13DraftSuppVersArray = [...]uint16{VersionTLS13Draft21, VersionTLS12, VersionTLS11, VersionTLS10, VersionSSL30}
 
 // getSupportedVersions returns the protocol versions that are supported by the
 // current configuration.

--- a/common.go
+++ b/common.go
@@ -29,6 +29,7 @@ const (
 	VersionTLS13        = 0x0304
 	VersionTLS13Draft18 = 0x7f00 | 18
 	VersionTLS13Draft21 = 0x7f00 | 21
+	VersionTLS13Draft22 = 0x7f00 | 22
 )
 
 const (
@@ -855,7 +856,7 @@ var configSuppVersArray = [...]uint16{VersionTLS13, VersionTLS12, VersionTLS11, 
 // with TLS 1.3 draft versions included.
 //
 // TODO: remove once TLS 1.3 is finalised.
-var tls13DraftSuppVersArray = [...]uint16{VersionTLS13Draft21, VersionTLS12, VersionTLS11, VersionTLS10, VersionSSL30}
+var tls13DraftSuppVersArray = [...]uint16{VersionTLS13Draft22, VersionTLS12, VersionTLS11, VersionTLS10, VersionSSL30}
 
 // getSupportedVersions returns the protocol versions that are supported by the
 // current configuration.

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -197,6 +197,11 @@ func (c *Conn) clientHandshake() error {
 			return err
 		}
 		hello.keyShares = []keyShare{clientKS}
+		// middlebox compatibility mode, provide a non-empty session ID
+		hello.sessionId = make([]byte, 16)
+		if _, err := io.ReadFull(c.config.rand(), hello.sessionId); err != nil {
+			return errors.New("tls: short read from Rand: " + err.Error())
+		}
 	}
 
 	if err = hs.handshake(); err != nil {

--- a/handshake_messages.go
+++ b/handshake_messages.go
@@ -2282,6 +2282,20 @@ func (m *newSessionTicketMsg13) unmarshal(data []byte) alert {
 	return alertSuccess
 }
 
+type endOfEarlyDataMsg struct {
+}
+
+func (*endOfEarlyDataMsg) marshal() []byte {
+	return []byte{typeEndOfEarlyData, 0, 0, 0}
+}
+
+func (*endOfEarlyDataMsg) unmarshal(data []byte) alert {
+	if len(data) != 4 {
+		return alertDecodeError
+	}
+	return alertSuccess
+}
+
 type helloRequestMsg struct {
 }
 

--- a/handshake_messages_test.go
+++ b/handshake_messages_test.go
@@ -317,7 +317,8 @@ func (*newSessionTicketMsg13) Generate(rand *rand.Rand, size int) reflect.Value 
 	m := &newSessionTicketMsg13{}
 	m.ageAdd = uint32(rand.Intn(0xffffffff))
 	m.lifetime = uint32(rand.Intn(0xffffffff))
-	m.ticket = randomBytes(rand.Intn(40), rand)
+	m.nonce = randomBytes(1+rand.Intn(255), rand)
+	m.ticket = randomBytes(1+rand.Intn(40), rand)
 	if rand.Intn(10) > 5 {
 		m.withEarlyDataInfo = true
 		m.maxEarlyDataLength = uint32(rand.Intn(0xffffffff))
@@ -345,7 +346,7 @@ func (*sessionState13) Generate(rand *rand.Rand, size int) reflect.Value {
 	s.ageAdd = uint32(rand.Intn(0xffffffff))
 	s.maxEarlyDataLen = uint32(rand.Intn(0xffffffff))
 	s.createdAt = uint64(rand.Int63n(0xfffffffffffffff))
-	s.resumptionSecret = randomBytes(rand.Intn(100), rand)
+	s.pskSecret = randomBytes(rand.Intn(100), rand)
 	s.alpnProtocol = randomString(rand.Intn(100), rand)
 	s.SNI = randomString(rand.Intn(100), rand)
 	return reflect.ValueOf(s)

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -262,6 +262,7 @@ Curves:
 		hs.hello13Enc = new(encryptedExtensionsMsg)
 		hs.hello.vers = c.vers
 		hs.hello.random = make([]byte, 32)
+		hs.hello.sessionId = hs.clientHello.sessionId
 		_, err = io.ReadFull(c.config.rand(), hs.hello.random)
 		if err != nil {
 			c.sendAlert(alertInternalError)


### PR DESCRIPTION
This PR implements the changes required for draft 22 support on the server and client sides. It starts with an update to draft 21 (untested for interop) and then continues with draft 22 changes.

Dependencies:
- [x] #34 prevent sending 0.5-RTT data (three patches added due to changes related to early data handling)

<!--
old branch without client support:
32ac5d616edc25d8eb20a8eb4419bb9f255653c9
-->