### PR TITLE
tris: integrate Haskell TLS in interop test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - MODE=interop CLIENT=boring SERVER=boring
   - MODE=interop CLIENT=tstclnt SERVER=tstclnt
   - MODE=interop CLIENT=picotls ZRTT=1
+  - MODE=interop CLIENT=hs-tls ZRTT=1
 # - MODE=interop CLIENT=mint    # does not support draft 22
   - MODE=bogo
   - MODE=gotest

--- a/_dev/hs-tls/Dockerfile
+++ b/_dev/hs-tls/Dockerfile
@@ -1,0 +1,15 @@
+FROM haskell:8.0
+
+RUN git clone https://github.com/kazu-yamamoto/hs-tls.git \
+    -b tls13 --single-branch
+
+# branch tls13 (as of 12 December 2017)
+ARG REVISION=a7936cfcf4ea95bb35b34b1640a356cee69157d6
+
+RUN cd hs-tls && git fetch && git checkout $REVISION
+RUN cd hs-tls && stack build
+
+ADD run.sh /run.sh
+ADD httpreq.txt /httpreq.txt
+WORKDIR /hs-tls
+ENTRYPOINT ["/run.sh"]

--- a/_dev/hs-tls/httpreq.txt
+++ b/_dev/hs-tls/httpreq.txt
@@ -1,0 +1,3 @@
+GET / HTTP/1.1
+Host: example.com
+

--- a/_dev/hs-tls/run.sh
+++ b/_dev/hs-tls/run.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+set -e
+
+IFS=':' read -ra ADDR <<< "$1"
+shift
+HOST="${ADDR[0]}"
+PORT="${ADDR[1]}"
+
+# Documentation:
+# https://github.com/vincenthz/hs-tls/issues/167#issuecomment-261823166
+# "-g x25519" is used since HRR is not supported yet by tris.
+
+exec stack exec tls-simpleclient -- --no-valid --http1.1 \
+    --session -Z /httpreq.txt -g x25519 "$HOST" "$PORT"


### PR DESCRIPTION
HRR is currently disabled because tris does not support it yet (#40). If HRR is implemented first, then this PR could be updated to check for that.