### PR TITLE
tris: remove github.com/cloudflare/go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: MODE=interop CLIENT=boring REVISION=origin/master
+    - env: MODE=interop CLIENT=tstclnt REVISION=default ZRTT=1
 
 install:
   - if [ "$MODE" = "interop" ]; then ./_dev/tris-localserver/start.sh -d && docker ps -a; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 
 go:
-  - 1.7
+  - 1.9.x
 
 env:
   - MODE=interop CLIENT=boring SERVER=boring
@@ -38,8 +38,3 @@ script:
 
 after_script:
   - if [ "$MODE" = "interop" ]; then docker ps -a; docker logs tris-localserver; fi
-
-cache:
-  directories:
-    - _dev/GOROOT
-    - _dev/go

--- a/_dev/Makefile
+++ b/_dev/Makefile
@@ -7,32 +7,19 @@ GOROOT: GOROOT/$(GOENV)/.ok_$(GOROOTINFO)
 	@rm -f GOROOT/$(GOENV)/pkg/*/crypto/tls.a
 
 GOROOT/$(GOENV)/.ok_$(GOROOTINFO):
-	rm -rf GOROOT/$(GOENV)
-	mkdir -p GOROOT/$(GOENV)/pkg
-	cp -r "$(shell $(GO) env GOROOT)/src" GOROOT/$(GOENV)/src
-	cp -r "$(shell $(GO) env GOROOT)/pkg/include" GOROOT/$(GOENV)/pkg/include
-	cp -r "$(shell $(GO) env GOROOT)/pkg/tool" GOROOT/$(GOENV)/pkg/tool
-	rm -r GOROOT/$(GOENV)/src/crypto/tls
-	ln -s ../../../../.. GOROOT/$(GOENV)/src/crypto/tls
-	GOROOT="$(CURDIR)/GOROOT/$(GOENV)" $(GO) install -v std
+	$(eval GOROOT := $(CURDIR)/GOROOT/$(GOENV))
+	rm -rf "$(GOROOT)"
+	mkdir -p "$(GOROOT)/pkg"
+	cp -r "$(shell $(GO) env GOROOT)/src" "$(GOROOT)/src"
+	cp -r "$(shell $(GO) env GOROOT)/pkg/include" "$(GOROOT)/pkg/include"
+	cp -r "$(shell $(GO) env GOROOT)/pkg/tool" "$(GOROOT)/pkg/tool"
+	rm -r "$(GOROOT)/src/crypto/tls"
+	ln -s ../../../../.. "$(GOROOT)/src/crypto/tls"
+	for p in $(wildcard $(CURDIR)/patches/*); do patch -d "$(GOROOT)" -p1 < "$$p"; done
+	GOROOT="$(GOROOT)" $(GO) install -v std
 ifeq ($(shell go env CGO_ENABLED),1)
-	GOROOT="$(CURDIR)/GOROOT/$(GOENV)" $(GO) install -race -v std
+	GOROOT="$(GOROOT)" $(GO) install -race -v std
 endif
-	@touch "$@"
-
-# Note: when changing this, if it doesn't change the Go version
-# (it should), you need to run make clean.
-GO_COMMIT := 88253a956a753213617d95af3f42a23a78798473
-
-.PHONY: go
-go: go/.ok_$(GO_COMMIT)_$(GOENV)
-
-go/.ok_$(GO_COMMIT)_$(GOENV):
-	rm -rf go/.ok_*_$(GOENV) go/$(GOENV)
-	mkdir -p go
-	git clone --branch 1.9 --single-branch --depth 25 https://github.com/cloudflare/go go/$(GOENV)
-	cd go/$(GOENV) && git checkout $(GO_COMMIT)
-	cd go/$(GOENV)/src && GOROOT_BOOTSTRAP="$(shell $(GO) env GOROOT)" ./make.bash
 	@touch "$@"
 
 .PHONY: clean

--- a/_dev/bogo/Dockerfile
+++ b/_dev/bogo/Dockerfile
@@ -1,9 +1,10 @@
-FROM golang:1.7-alpine
+FROM golang:1.9-alpine
 
 RUN apk add --update \
     git \
     make \
     bash \
+    patch \
   && rm -rf /var/cache/apk/*
 
 ENV CGO_ENABLED=0

--- a/_dev/go.sh
+++ b/_dev/go.sh
@@ -2,12 +2,9 @@
 set -e
 
 BASEDIR=$(cd "$(dirname "$0")" && pwd)
-
-make --quiet -C "$BASEDIR" go >&2
 GOENV="$(go env GOHOSTOS)_$(go env GOHOSTARCH)"
 
-export GOROOT="$BASEDIR/go/$GOENV"
-make --quiet -C "$BASEDIR" GOROOT GO="$BASEDIR/go/$GOENV/bin/go" >&2
-export GOROOT="$BASEDIR/GOROOT/$GOENV"
+make --quiet -C "$BASEDIR" GOROOT >&2
 
-exec $BASEDIR/go/$GOENV/bin/go "$@"
+export GOROOT="$BASEDIR/GOROOT/$GOENV"
+exec go "$@"

--- a/_dev/patches/88253a956a753213617d95af3f42a23a78798473.patch
+++ b/_dev/patches/88253a956a753213617d95af3f42a23a78798473.patch
@@ -1,0 +1,63 @@
+From 88253a956a753213617d95af3f42a23a78798473 Mon Sep 17 00:00:00 2001
+From: Filippo Valsorda <filippo@cloudflare.com>
+Date: Mon, 28 Nov 2016 05:24:21 +0000
+Subject: [PATCH] net/http: attach TLSConnContextKey to the request Context
+
+Change-Id: Ic59c84f992c829dc7da741b128dd6899366fa1d2
+---
+ src/net/http/request.go |  4 +++-
+ src/net/http/server.go  | 12 ++++++++++++
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/src/net/http/request.go b/src/net/http/request.go
+index 13f367c1a8..b2827ff123 100644
+--- a/src/net/http/request.go
++++ b/src/net/http/request.go
+@@ -275,7 +275,9 @@ type Request struct {
+ 	// was received. This field is not filled in by ReadRequest.
+ 	// The HTTP server in this package sets the field for
+ 	// TLS-enabled connections before invoking a handler;
+-	// otherwise it leaves the field nil.
++	// otherwise it leaves the field nil. The value is fixed
++	// at the state of the connection immediately after Handshake,
++	// for an immediate value use TLSConnContextKey.
+ 	// This field is ignored by the HTTP client.
+ 	TLS *tls.ConnectionState
+ 
+diff --git a/src/net/http/server.go b/src/net/http/server.go
+index 2fa8ab23d8..b0542cdbc3 100644
+--- a/src/net/http/server.go
++++ b/src/net/http/server.go
+@@ -223,6 +223,12 @@ var (
+ 	// the local address the connection arrived on.
+ 	// The associated value will be of type net.Addr.
+ 	LocalAddrContextKey = &contextKey{"local-addr"}
++
++	// TLSConnContextKey is a context key. It can be used in
++	// HTTP handlers with context.WithValue to access the
++	// underlying *tls.Conn being served. If the connection
++	// is not TLS, the key is not set.
++	TLSConnContextKey = &contextKey{"tls-conn"}
+ )
+ 
+ // A conn represents the server side of an HTTP connection.
+@@ -969,6 +975,9 @@ func (c *conn) readRequest(ctx context.Context) (w *response, err error) {
+ 	delete(req.Header, "Host")
+ 
+ 	ctx, cancelCtx := context.WithCancel(ctx)
++	if tlsConn, ok := c.rwc.(*tls.Conn); ok {
++		ctx = context.WithValue(ctx, TLSConnContextKey, tlsConn)
++	}
+ 	req.ctx = ctx
+ 	req.RemoteAddr = c.remoteAddr
+ 	req.TLS = c.tlsState
+@@ -3161,6 +3170,9 @@ func (h initNPNRequest) ServeHTTP(rw ResponseWriter, req *Request) {
+ 	if req.RemoteAddr == "" {
+ 		req.RemoteAddr = h.c.RemoteAddr().String()
+ 	}
++	if req.ctx != nil && req.ctx.Value(TLSConnContextKey) == nil {
++		req.ctx = context.WithValue(req.ctx, TLSConnContextKey, h.c)
++	}
+ 	h.h.ServeHTTP(rw, req)
+ }
+ 

--- a/_dev/tris-testclient/build.sh
+++ b/_dev/tris-testclient/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
 cd "$(dirname "$0")"
-GOOS=linux ../go.sh build -v -i .
+CGO_ENABLED=0 GOOS=linux ../go.sh build -v -i .
 docker build -t tris-testclient .


### PR DESCRIPTION
Over time the amount of custom Go patches reduced, and tris got less
tangled to the underlying Go. Finally sever the link.

This allows more flexibility in what base Go is used (the system one),
doesn't require coordinating two repositories, and simplifies the black
magic considerably.

Make sure to use tris with Go 1.9 or higher.