### PR TITLE
Ed25519 certificates

### DIFF
--- a/13_test.go
+++ b/13_test.go
@@ -1,0 +1,72 @@
+package tls
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"golang_org/x/crypto/ed25519"
+)
+
+func TestEd25519(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{}
+	template.SerialNumber, _ = rand.Int(rand.Reader, big.NewInt(1<<62))
+	template.ExtKeyUsage = append(template.ExtKeyUsage, x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth)
+	cert, err := x509.CreateCertificate(rand.Reader, template, template, pub, priv)
+
+	config := testConfig.Clone()
+	config.MinVersion = VersionTLS13
+	config.MaxVersion = VersionTLS13
+	config.Certificates = []Certificate{
+		Certificate{
+			Certificate: [][]byte{cert},
+			PrivateKey:  priv,
+		},
+	}
+
+	ln := newLocalListener(t)
+	defer ln.Close()
+
+	server := func() error {
+		sconn, err := ln.Accept()
+		if err != nil {
+			return fmt.Errorf("accept: %v", err)
+		}
+		defer sconn.Close()
+
+		srv := Server(sconn, config)
+		if err := srv.Handshake(); err != nil {
+			t.Log("server handshake error:", err)
+			return fmt.Errorf("handshake: %v", err)
+		}
+		return srv.Close()
+	}
+
+	errChan := make(chan error, 1)
+	go func() { errChan <- server() }()
+
+	conn, err := Dial("tcp", ln.Addr().String(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.Handshake(); err != nil {
+		conn.Close()
+		t.Fatal(err)
+	}
+
+	if _, err := conn.Write([]byte("Hello, World!")); err != nil {
+		conn.Close()
+		t.Fatal(err)
+	}
+	conn.Close()
+
+	if err := <-errChan; err != nil {
+		t.Fatal(err)
+	}
+}

--- a/common.go
+++ b/common.go
@@ -168,6 +168,7 @@ const (
 	signaturePKCS1v15 uint8 = iota + 1
 	signatureECDSA
 	signatureRSAPSS
+	signatureEd25519
 )
 
 // supportedSignatureAlgorithms contains the signature and hash algorithms that
@@ -186,8 +187,9 @@ var supportedSignatureAlgorithms = []SignatureScheme{
 }
 
 // supportedSignatureAlgorithms13 lists the advertised signature algorithms
-// allowed for digital signatures. It includes TLS 1.2 + PSS.
+// allowed for digital signatures. It includes TLS 1.2 + PSS + Ed25519.
 var supportedSignatureAlgorithms13 = []SignatureScheme{
+	Ed25519,
 	PSSWithSHA256,
 	PKCS1WithSHA256,
 	ECDSAWithP256AndSHA256,
@@ -290,6 +292,8 @@ const (
 	ECDSAWithP256AndSHA256 SignatureScheme = 0x0403
 	ECDSAWithP384AndSHA384 SignatureScheme = 0x0503
 	ECDSAWithP521AndSHA512 SignatureScheme = 0x0603
+
+	Ed25519 SignatureScheme = 0x0807
 
 	// Legacy signature and hash algorithms for TLS 1.2.
 	ECDSAWithSHA1 SignatureScheme = 0x0203
@@ -969,9 +973,9 @@ type Certificate struct {
 	Certificate [][]byte
 	// PrivateKey contains the private key corresponding to the public key
 	// in Leaf. For a server, this must implement crypto.Signer and/or
-	// crypto.Decrypter, with an RSA or ECDSA PublicKey. For a client
+	// crypto.Decrypter, with an RSA, ECDSA or Ed25519 PublicKey. For a client
 	// (performing client authentication), this must be a crypto.Signer
-	// with an RSA or ECDSA PublicKey.
+	// with an RSA, ECDSA or Ed25519 PublicKey.
 	PrivateKey crypto.PrivateKey
 	// OCSPStaple contains an optional OCSP response which will be served
 	// to clients that request it.
@@ -1179,6 +1183,8 @@ func signatureFromSignatureScheme(signatureAlgorithm SignatureScheme) uint8 {
 		return signatureRSAPSS
 	case ECDSAWithSHA1, ECDSAWithP256AndSHA256, ECDSAWithP384AndSHA384, ECDSAWithP521AndSHA512:
 		return signatureECDSA
+	case Ed25519:
+		return signatureEd25519
 	default:
 		return 0
 	}

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -18,6 +18,8 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+
+	"golang_org/x/crypto/ed25519"
 )
 
 type clientHandshakeState struct {
@@ -400,7 +402,7 @@ func (hs *clientHandshakeState) processCertsFromServer(certificates [][]byte) er
 	}
 
 	switch certs[0].PublicKey.(type) {
-	case *rsa.PublicKey, *ecdsa.PublicKey:
+	case *rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey:
 		break
 	default:
 		c.sendAlert(alertUnsupportedCertificate)

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"io"
 	"sync/atomic"
+
+	"golang_org/x/crypto/ed25519"
 )
 
 type Committer interface {
@@ -309,6 +311,11 @@ Curves:
 			hs.ecdsaOk = true
 		case *rsa.PublicKey:
 			hs.rsaSignOk = true
+		case ed25519.PublicKey:
+			if c.vers < VersionTLS13 {
+				c.sendAlert(alertInternalError)
+				return false, errors.New("tls: ed25519 only supported with version 1.3")
+			}
 		default:
 			c.sendAlert(alertInternalError)
 			return false, fmt.Errorf("tls: unsupported signing key type (%T)", priv.Public())

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -324,7 +324,7 @@ Curves:
 		}
 	}
 
-	if c.vers != VersionTLS13 && hs.checkForResumption() {
+	if c.vers < VersionTLS13 && hs.checkForResumption() {
 		return true, nil
 	}
 

--- a/prf.go
+++ b/prf.go
@@ -188,6 +188,8 @@ func lookupTLSHash(signatureAlgorithm SignatureScheme) (crypto.Hash, error) {
 		return crypto.SHA384, nil
 	case PKCS1WithSHA512, PSSWithSHA512, ECDSAWithP521AndSHA512:
 		return crypto.SHA512, nil
+	case Ed25519:
+		return 0, nil
 	default:
 		return 0, fmt.Errorf("tls: unsupported signature algorithm: %#04x", signatureAlgorithm)
 	}


### PR DESCRIPTION
Ed25519 is specified in the spec https://tools.ietf.org/html/draft-ietf-curdle-pkix-07. TLS 1.3 defines the SignatureScheme for Ed25519.

This requires a patch like https://github.com/golang/go/compare/master...FiloSottile:filippo/ed25519 first, so is not a ready-to-merge PR, just some code I wanted to put out there. Feel free to close the PR or keep it around.

There's also a small bugfix commit you might want to cherry-pick.