### PR TITLE
Revert "Use go 1.10 and aligns with current state of TLS in go/crypto/tls"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 
 go:
-  - 1.10.x
+  - 1.9.x
 
 env:
   - MODE=interop CLIENT=boring SERVER=boring

--- a/_dev/bogo/Dockerfile
+++ b/_dev/bogo/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine
+FROM golang:1.9-alpine
 
 RUN apk add --update \
     git \

--- a/cipher_suites.go
+++ b/cipher_suites.go
@@ -387,7 +387,7 @@ func mutualCipherSuite(have []uint16, want uint16) *cipherSuite {
 // A list of cipher suite IDs that are, or have been, implemented by this
 // package.
 //
-// Taken from https://www.iana.org/assignments/tls-parameters/tls-parameters.xml
+// Taken from http://www.iana.org/assignments/tls-parameters/tls-parameters.xml
 const (
 	// TLS 1.0 - 1.2 cipher suites.
 	TLS_RSA_WITH_RC4_128_SHA                uint16 = 0x0005

--- a/common.go
+++ b/common.go
@@ -108,7 +108,7 @@ const (
 )
 
 // CurveID is the type of a TLS identifier for an elliptic curve. See
-// https://www.iana.org/assignments/tls-parameters/tls-parameters.xml#tls-parameters-8
+// http://www.iana.org/assignments/tls-parameters/tls-parameters.xml#tls-parameters-8
 //
 // TLS 1.3 refers to these as Groups, but this library implements only
 // curve-based ones anyway. See https://tools.ietf.org/html/draft-ietf-tls-tls13-18#section-4.2.4.
@@ -138,7 +138,7 @@ type psk struct {
 }
 
 // TLS Elliptic Curve Point Formats
-// https://www.iana.org/assignments/tls-parameters/tls-parameters.xml#tls-parameters-9
+// http://www.iana.org/assignments/tls-parameters/tls-parameters.xml#tls-parameters-9
 const (
 	pointFormatUncompressed uint8 = 0
 )

--- a/common.go
+++ b/common.go
@@ -483,9 +483,8 @@ type Config struct {
 	//
 	// If normal verification fails then the handshake will abort before
 	// considering this callback. If normal verification is disabled by
-	// setting InsecureSkipVerify, or (for a server) when ClientAuth is
-	// RequestClientCert or RequireAnyClientCert, then this callback will
-	// be considered but the verifiedChains argument will always be nil.
+	// setting InsecureSkipVerify then this callback will be considered but
+	// the verifiedChains argument will always be nil.
 	VerifyPeerCertificate func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error
 
 	// RootCAs defines the set of root certificate authorities

--- a/generate_cert.go
+++ b/generate_cert.go
@@ -146,24 +146,16 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to open cert.pem for writing: %s", err)
 	}
-	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
-		log.Fatalf("failed to write data to cert.pem: %s", err)
-	}
-	if err := certOut.Close(); err != nil {
-		log.Fatalf("error closing cert.pem: %s", err)
-	}
-	log.Print("wrote cert.pem\n")
+	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	certOut.Close()
+	log.Print("written cert.pem\n")
 
 	keyOut, err := os.OpenFile("key.pem", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		log.Print("failed to open key.pem for writing:", err)
 		return
 	}
-	if err := pem.Encode(keyOut, pemBlockForKey(priv)); err != nil {
-		log.Fatalf("failed to write data to key.pem: %s", err)
-	}
-	if err := keyOut.Close(); err != nil {
-		log.Fatalf("error closing key.pem: %s", err)
-	}
-	log.Print("wrote key.pem\n")
+	pem.Encode(keyOut, pemBlockForKey(priv))
+	keyOut.Close()
+	log.Print("written key.pem\n")
 }


### PR DESCRIPTION
Reverts cloudflare/tls-tris#72.
I'll create new PR with commits that will be easier to upstream later. It's simple branch maintenance, resulting code will be exactly the same.