### PR TITLE
Get the code to build on Ubuntu >=18.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ pip install setuptools
 pip install docker
 ```
 
+* In Ubuntu (>=18.04), you'll also need to `apt install docker.io`. If docker
+  tells you don't have permission to access the daemon, try adding yourself to
+  the `docker` group via:
+  ```
+    sudo usermod -a -G docker $USER
+  ```
+
 Similar dependencies can be found on any UNIX based system/distribution.
 
 ### Building

--- a/_dev/Makefile
+++ b/_dev/Makefile
@@ -37,9 +37,9 @@ $(BUILD_DIR)/$(OS_ARCH)/.ok_$(VER_OS_ARCH): clean
 	mkdir -p "$(GOROOT_LOCAL)/pkg"
 
 # Copy src/tools from system GOROOT
-	cp -r $(GOROOT_ENV)/src $(GOROOT_LOCAL)/src
-	cp -r $(GOROOT_ENV)/pkg/include $(GOROOT_LOCAL)/pkg/include
-	cp -r $(GOROOT_ENV)/pkg/tool $(GOROOT_LOCAL)/pkg/tool
+	cp -Hr $(GOROOT_ENV)/src $(GOROOT_LOCAL)/src
+	cp -Hr $(GOROOT_ENV)/pkg/include $(GOROOT_LOCAL)/pkg/include
+	cp -Hr $(GOROOT_ENV)/pkg/tool $(GOROOT_LOCAL)/pkg/tool
 
 # Swap TLS implementation
 	rm -r $(GOROOT_LOCAL)/src/crypto/tls/*


### PR DESCRIPTION
I needed to amend `_dev/Makefile` slightly. On my system, some of the folders in GOROOT are symbolic links to directories the Makefile tries to copy. Adding the `-H` flag to `cp` solves this, and AFAICT should not affect the build on other systems.

I also added some notes to `README.md` for getting things to run on Ubuntu.