### PR TITLE
Skeleton for delegated_credential: TLS imports DC

### DIFF
--- a/_dev/Makefile
+++ b/_dev/Makefile
@@ -93,6 +93,7 @@ test: \
 	test-interop
 
 test-unit: $(BUILD_DIR)/$(OS_ARCH)/.ok_$(VER_OS_ARCH)
+	GOROOT="$(GOROOT_LOCAL)" $(GO) test -race crypto/tls/delegated_credential
 	GOROOT="$(GOROOT_LOCAL)" $(GO) test -race crypto/tls
 
 test-bogo:

--- a/common.go
+++ b/common.go
@@ -10,6 +10,7 @@ import (
 	"crypto/internal/cipherhw"
 	"crypto/rand"
 	"crypto/sha512"
+	reg "crypto/tls/registry"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -296,6 +297,22 @@ const (
 	ECDSAWithSHA1 SignatureScheme = 0x0203
 )
 
+// Register the codes for signature schemes; these will be needed by extensions.
+func init() {
+	reg.RegisterSignatureScheme("ECDSAWithP256AndSHA256", uint16(ECDSAWithP256AndSHA256))
+	reg.RegisterSignatureScheme("PKCS1WithSHA1", uint16(PKCS1WithSHA1))
+	reg.RegisterSignatureScheme("PKCS1WithSHA256", uint16(PKCS1WithSHA256))
+	reg.RegisterSignatureScheme("PKCS1WithSHA384", uint16(PKCS1WithSHA384))
+	reg.RegisterSignatureScheme("PKCS1WithSHA512", uint16(PKCS1WithSHA512))
+	reg.RegisterSignatureScheme("PSSWithSHA256", uint16(PSSWithSHA256))
+	reg.RegisterSignatureScheme("PSSWithSHA384", uint16(PSSWithSHA384))
+	reg.RegisterSignatureScheme("PSSWithSHA512", uint16(PSSWithSHA512))
+	reg.RegisterSignatureScheme("ECDSAWithP256AndSHA256", uint16(ECDSAWithP256AndSHA256))
+	reg.RegisterSignatureScheme("ECDSAWithP384AndSHA384", uint16(ECDSAWithP384AndSHA384))
+	reg.RegisterSignatureScheme("ECDSAWithP521AndSHA512", uint16(ECDSAWithP521AndSHA512))
+	reg.RegisterSignatureScheme("ECDSAWithSHA1", uint16(ECDSAWithSHA1))
+}
+
 // ClientHelloInfo contains information from a ClientHello message in order to
 // guide certificate selection in the GetCertificate callback.
 type ClientHelloInfo struct {
@@ -407,10 +424,11 @@ const (
 // modified. A Config may be reused; the tls package will also not
 // modify it.
 type Config struct {
-	// Rand provides the source of entropy for nonces and RSA blinding.
-	// If Rand is nil, TLS uses the cryptographic random reader in package
-	// crypto/rand.
-	// The Reader must be safe for use by multiple goroutines.
+	// Rand provides the source of entropy for cryptographic operations,
+	// including ranodm nonce generation, key (share) generation, and public-key
+	// encryption. If Rand is nil, TLS uses the cryptographic random reader in
+	// package crypto/rand. The Reader must be safe for use by multiple
+	// goroutines.
 	Rand io.Reader
 
 	// Time returns the current time as the number of seconds since the epoch.

--- a/delegated_credential/delegated_credential.go
+++ b/delegated_credential/delegated_credential.go
@@ -1,0 +1,142 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package delegated_credential
+
+import (
+	"crypto"
+	reg "crypto/tls/registry"
+	"crypto/x509"
+	"time"
+)
+
+const (
+	MaxTTLSeconds   = 60 * 60 * 24 * 7 // Seconds
+	MaxTTL          = time.Duration(MaxTTLSeconds) * time.Nanosecond
+	MaxPublicKeyLen = 1 << 16 // Bytes
+)
+
+// Credential stores the public components of the credential.
+//
+// TODO(cjpatton) Rename DelegatedCredentialParams in the draft.
+type Credential struct {
+
+	// Time in nonsecnds for which the credential is valid. When this data
+	// structure is serialized, this value is converted to a uint32 representing
+	// the duration in seconds.
+	ValidTime time.Duration
+
+	// The public key of the credential.
+	PublicKey crypto.PublicKey
+
+	// The signature scheme corresponding to PublicKey.
+	scheme uint16
+}
+
+// NewECDSACredential generates an ECDSA key pair for the specified group and
+// returns the secret key and a credential with the public key and validity
+// time.
+func NewCredential(
+	scheme uint16,
+	validTime time.Duration) (crypto.PrivateKey, *Credential, error) {
+	// TODO(cjpatton)
+	return nil, nil, nil
+}
+
+// IsExpired returns true if and only if the credential has not expired.  The
+// end of the validity interval is defined as the deleagtor certificate's
+// notBefore field plus validTime seconds. This function simply checks that the
+// current time is before the end of the valdity interval.
+func (cred *Credential) IsExpired(start, now time.Time) bool {
+	// TODO(cjpatton)
+	return false
+}
+
+func (cred *Credential) HasValidTTL(start, now time.Time) bool {
+	// TODO(cjpatton)
+	return false
+}
+
+// Marshal encodes a credential as per the spec.
+func (cred *Credential) Marshal() ([]byte, error) {
+	// TODO(cjpatton)
+	return nil, nil
+}
+
+// UnmarshalCredential decodes a credential.
+func UnmarshalCredential(serialized []byte) (*Credential, error) {
+	// TODO(cjpatton)
+	return nil, nil
+}
+
+// Delegator stores the secret key of the delegator.
+//
+// This does not implement crypto.Signer, because this interface only works for
+// PKCS1, PSS, and ECDSA signature schemes. We also want to permit use of EdDSA,
+// which has a different interface.
+type Delegator struct {
+
+	// the delegation key, i.e., the signing key of the delegator.
+	delegationKey crypto.PrivateKey
+
+	// The certificate of the delegator.
+	//
+	// TODO(cjpatton) Determine if the delegator is meant to sign the whole
+	// chain, or just the leaf. (The spec is a bit ambiguous about this.)
+	cert *x509.Certificate
+
+	// The signing algorithm of the delegation key. This must be a uint16 as per
+	// the TLS 1.3 spec.
+	scheme uint16
+}
+
+// NewDelegator initializes the delegator state using the delagation key and the
+// corresponding certificate cert. It ensures that the public key corresponding
+// to delegationKey is the same public key as in cert. It also ensures that
+// certificate can be used for delegation, as per the spec.
+func NewDelegator(
+	delegationKey crypto.PrivateKey, cert *x509.Certificate) (*Delegator, error) {
+	// TODO(cjpatton)
+	return nil, nil
+}
+
+// Delegate signs a credential, binding it to the provided version
+//
+// TODO(cjpatton) Formalize the searizlizing of the input in the spec.
+func (del *Delegator) Delegate(
+	cred *Credential, ver uint16) (*DelegatedCredential, error) {
+	// TODO(cjpatton)
+	return nil, nil
+}
+
+// DelegatedCredential is a Credential structure signed in a given context.
+type DelegatedCredential struct {
+	Cred      Credential // The credential
+	Scheme    uint16     // The algorithm used to sign the credential
+	Signature []byte     // The signature
+}
+
+// Validate checks that that the signature is valid, that the credential hasn't
+// expired, and that it's TTL is less than 7 days. It also checks that
+// certificate can be used for delegation, per the spec.
+func (dc *DelegatedCredential) Validate(
+	cert *x509.Certificate, ver uint16, now time.Time) (bool, error) {
+	// TODO(cjpatton)
+	return false, nil
+}
+
+func (dc *DelegatedCredential) Marshal() []byte {
+	// TODO(cjpatton)
+	return nil
+}
+
+func UnmarshalDelegatedCredential(serialized []byte) *DelegatedCredential {
+	// TODO(cjpatton)
+	return nil
+}
+
+// TODO(cjpatton) Remove this. It's only here for testing.
+func RequireECDSAWithP256AndSHA256() uint16 {
+	return reg.GetSignatureScheme("ECDSAWithP256AndSHA256")
+}

--- a/delegated_credential/delegated_credential_test.go
+++ b/delegated_credential/delegated_credential_test.go
@@ -1,0 +1,13 @@
+package delegated_credential_test
+
+import (
+	_ "crypto/tls"
+	deleg "crypto/tls/delegated_credential"
+
+	"testing"
+)
+
+// TODO(cjpatton)
+func TestDelegateVerify(t *testing.T) {
+	t.Log(deleg.RequireECDSAWithP256AndSHA256())
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,0 +1,26 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This package is used to register TLS constants needed by extensions.
+package registry
+
+import "fmt"
+
+var schemes map[string]uint16
+
+func init() {
+	schemes = make(map[string]uint16)
+}
+
+func GetSignatureScheme(key string) uint16 {
+	val, ok := schemes[key]
+	if !ok {
+		panic(fmt.Sprintf("scheme not registered: %s", key))
+	}
+	return val
+}
+
+func RegisterSignatureScheme(key string, val uint16) {
+	schemes[key] = val
+}


### PR DESCRIPTION
This is an alternative to #91.

Instead of having DC register its extension, we have TLS register the constants needed by DC. This means adding some code to `common.go`, but lets us test DC integration in the TLS package. This method would be much more cumbersome than #91, however.

PR #91 is more "upstreamable", this PR might allow us to write tests with better coverage.