### PR TITLE
Remove the DC minting API

### DIFF
--- a/13.go
+++ b/13.go
@@ -408,7 +408,7 @@ func (hs *serverHandshakeState) sendCertificate13() error {
 	// server is using the delegated credential extension. In TLS 1.3, the DC is
 	// added as an extension to the end-entity certificate, i.e., the last
 	// CertificateEntry of Certificate.certficate_list (see
-	// https://tools.ietf.org/html/draft-ietf-tls-subcerts).
+	// https://tools.ietf.org/html/draft-ietf-tls-subcerts-01).
 	if len(certEntries) > 0 && hs.clientHello.delegatedCredential && hs.delegatedCredential != nil {
 		certEntries[0].delegatedCredential = hs.delegatedCredential
 	}
@@ -1069,7 +1069,7 @@ func (hs *clientHandshakeState) doTLS13Handshake() error {
 	// then the  CertificateVerify signature will have been produced with the
 	// DelegatedCredential's private key.
 	if hs.c.verifiedDc != nil {
-		pk = hs.c.verifiedDc.PublicKey
+		pk = hs.c.verifiedDc.cred.publicKey
 	}
 
 	// Receive CertificateVerify message.

--- a/conn.go
+++ b/conn.go
@@ -58,7 +58,7 @@ type Conn struct {
 	verifiedChains [][]*x509.Certificate
 	// verifiedDc is set by a client who negotiates the use of a valid delegated
 	// credential.
-	verifiedDc *DelegatedCredential
+	verifiedDc *delegatedCredential
 	// serverName contains the server name indicated by the client, if any.
 	serverName string
 	// secureRenegotiation is true if the server echoed the secure
@@ -1666,6 +1666,9 @@ func (c *Conn) ConnectionState() ConnectionState {
 		state.VerifiedChains = c.verifiedChains
 		state.SignedCertificateTimestamps = c.scts
 		state.OCSPResponse = c.ocspResponse
+		if c.verifiedDc != nil {
+			state.DelegatedCredential = c.verifiedDc.raw
+		}
 		state.HandshakeConfirmed = atomic.LoadInt32(&c.handshakeConfirmed) == 1
 		if !state.HandshakeConfirmed {
 			state.Unique0RTTToken = c.binder

--- a/generate_cert.go
+++ b/generate_cert.go
@@ -14,7 +14,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -35,7 +34,6 @@ var (
 	isCA       = flag.Bool("ca", false, "whether this cert should be its own Certificate Authority")
 	rsaBits    = flag.Int("rsa-bits", 2048, "Size of RSA key to generate. Ignored if --ecdsa-curve is set")
 	ecdsaCurve = flag.String("ecdsa-curve", "", "ECDSA curve to use to generate a key. Valid values are P224, P256 (recommended), P384, P521")
-	isDC       = flag.Bool("dc", false, "whether this cert can be used with delegated credentials")
 )
 
 func publicKey(priv interface{}) interface{} {
@@ -137,11 +135,6 @@ func main() {
 	if *isCA {
 		template.IsCA = true
 		template.KeyUsage |= x509.KeyUsageCertSign
-	}
-
-	if *isDC {
-		template.ExtraExtensions = append(
-			template.ExtraExtensions, *tls.CreateDelegationUsagePKIXExtension())
 	}
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)

--- a/handshake_messages.go
+++ b/handshake_messages.go
@@ -759,7 +759,7 @@ func (m *clientHelloMsg) unmarshal(data []byte) alert {
 			// https://tools.ietf.org/html/draft-ietf-tls-tls13-18#section-4.2.8
 			m.earlyData = true
 		case extensionDelegatedCredential:
-			// https://tools.ietf.org/html/draft-ietf-tls-subcerts
+			// https://tools.ietf.org/html/draft-ietf-tls-subcerts-01
 			m.delegatedCredential = true
 		}
 		data = data[length:]

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -329,14 +329,7 @@ Curves:
 		// Set the handshake private key.
 		if dc != nil {
 			hs.privateKey = sk
-			if dc.Raw == nil {
-				dc.Raw, err = dc.Marshal()
-				if err != nil {
-					c.sendAlert(alertInternalError)
-					return false, err
-				}
-			}
-			hs.delegatedCredential = dc.Raw
+			hs.delegatedCredential = dc
 
 			// For TLS 1.2, the DC is an extension to the ServerHello.
 			if c.vers == VersionTLS12 {

--- a/subcerts_test.go
+++ b/subcerts_test.go
@@ -14,14 +14,10 @@ import (
 	"time"
 )
 
-// These test keys were generated with the following program, available in the
-// crypto/tls directory:
-//
-//		go run generate_cert.go -ecdsa-curve P256 -host 127.0.0.1 -dc
-//
-// To get a certificate without the DelegationUsage extension, remove the `-dc`
-// parameter.
-var delegatorCertPEM = `-----BEGIN CERTIFICATE-----
+// A PEM-encoded "delegation certificate", an X.509 certificate with the
+// DelegationUsage extension. The extension is defined in
+// specified in https://tools.ietf.org/html/draft-ietf-tls-subcerts-01.
+var dcDelegationCertPEM = `-----BEGIN CERTIFICATE-----
 MIIBdzCCAR2gAwIBAgIQLVIvEpo0/0TzRja4ImvB1TAKBggqhkjOPQQDAjASMRAw
 DgYDVQQKEwdBY21lIENvMB4XDTE4MDcwMzE2NTE1M1oXDTE5MDcwMzE2NTE1M1ow
 EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABOhB
@@ -33,14 +29,17 @@ OetDIvU4mdyoAiAGN97y3GJccYn9ZOJS4UOqhr9oO8PuZMLgdq4OrMRiiA==
 -----END CERTIFICATE-----
 `
 
-var delegatorKeyPEM = `-----BEGIN EC PRIVATE KEY-----
+// The PEM-encoded "delegation key", the secret key associated with the
+// delegation certificate.
+var dcDelegationKeyPEM = `-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIJDVlo+sJolMcNjMkfCGDUjMJcE4UgclcXGCrOtbJAi2oAoGCCqGSM49
 AwEHoUQDQgAE6EFTpp1oCCWItoVzU8Cj0cE7haKyHUbh1/cgrkRcvL6ihh+aR/NP
 UXGps0tm581jO97bl+alqX/VUkCOlXIqrQ==
 -----END EC PRIVATE KEY-----
 `
 
-var nonDelegatorCertPEM = `-----BEGIN CERTIFICATE-----
+// A certificate without the DelegationUsage extension.
+var dcCertPEM = `-----BEGIN CERTIFICATE-----
 MIIBaTCCAQ6gAwIBAgIQSUo+9uaip3qCW+1EPeHZgDAKBggqhkjOPQQDAjASMRAw
 DgYDVQQKEwdBY21lIENvMB4XDTE4MDYxMjIzNDAyNloXDTE5MDYxMjIzNDAyNlow
 EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABLf7
@@ -52,13 +51,25 @@ AwIDSQAwRgIhANXG0zmrVtQBK0TNZZoEGMOtSwxmiZzXNe+IjdpxO3TiAiEA5VYx
 -----END CERTIFICATE-----
 `
 
-var nonDelegatorKeyPEM = `-----BEGIN EC PRIVATE KEY-----
+// The secret key associatted with dcCertPEM.
+var dcKeyPEM = `-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIMw9DiOfGI1E/XZrrW2huZSjYi0EKwvVjAe+dYtyFsSloAoGCCqGSM49
 AwEHoUQDQgAEt/t+LOc9V1zdXmYzfKazBTb8iglqr914Dp2B2PnSjN1jJGIA+PHN
 zP3NGxnDVqlMX+HI1+IuFXgQTVWvBdxPkw==
 -----END EC PRIVATE KEY-----
 `
 
+// dcTestDC stores delegated credentials and their secret keys.
+type dcTestDC struct {
+	Name       string
+	Version    int
+	Scheme     int
+	DC         []byte
+	PrivateKey []byte
+}
+
+// Test data used for testing the TLS handshake with the delegated creedential
+// extension. The PEM block encodes a DER encoded slice of dcTestDC's.
 var dcTestDCsPEM = `-----BEGIN DC TEST DATA-----
 MIIGQzCCAToTBXRsczEyAgIDAwICBAMEga0ACUp3AFswWTATBgcqhkjOPQIBBggq
 hkjOPQMBBwNCAAQ9z9RDrMvyRzPOkw9SK2S/O5DiwfRNjAwYcq7e/sKdN0ZcSP1K
@@ -97,14 +108,6 @@ HJbn52hmB027JEIMPWsxKxPkr7udk7Q=
 -----END DC TEST DATA-----
 `
 
-type dcTestDC struct {
-	Name       string
-	Version    int
-	Scheme     int
-	DC         []byte
-	PrivateKey []byte
-}
-
 var dcTestDCs []dcTestDC
 var dcTestConfig *Config
 var dcTestDelegationCert Certificate
@@ -112,8 +115,7 @@ var dcTestCert Certificate
 var dcTestNow time.Time
 
 func init() {
-
-	// Parse the PEM-encoded DER block containing the test DCs.
+	// Parse the PEM block containing the test DCs.
 	block, _ := pem.Decode([]byte(dcTestDCsPEM))
 	if block == nil {
 		panic("failed to decode DC tests PEM block")
@@ -142,7 +144,7 @@ func init() {
 	}
 
 	// The delegation certificate.
-	dcTestDelegationCert, err = X509KeyPair([]byte(delegatorCertPEM), []byte(delegatorKeyPEM))
+	dcTestDelegationCert, err = X509KeyPair([]byte(dcDelegationCertPEM), []byte(dcDelegationKeyPEM))
 	if err != nil {
 		panic(err)
 	}
@@ -152,7 +154,7 @@ func init() {
 	}
 
 	// A certificate without the the DelegationUsage extension for X.509.
-	dcTestCert, err = X509KeyPair([]byte(nonDelegatorCertPEM), []byte(nonDelegatorKeyPEM))
+	dcTestCert, err = X509KeyPair([]byte(dcCertPEM), []byte(dcKeyPEM))
 	if err != nil {
 		panic(err)
 	}
@@ -179,9 +181,9 @@ func init() {
 	dcTestConfig.RootCAs.AddCert(root)
 }
 
-// Tests the handshake and one round of application data. Returns true if the
-// connection used a DC.
-func testConnWithDC(t *testing.T, clientMsg, serverMsg string, clientConfig, serverConfig *Config) (bool, error) {
+// Executes the handshake with the given configuration and returns true if the
+// delegated credential extension was successfully negotiated.
+func testConnWithDC(t *testing.T, clientConfig, serverConfig *Config) (bool, error) {
 	ln := newLocalListener(t)
 	defer ln.Close()
 
@@ -216,28 +218,9 @@ func testConnWithDC(t *testing.T, clientMsg, serverMsg string, clientConfig, ser
 		return false, serr
 	}
 
-	bufLen := len(clientMsg)
-	if len(serverMsg) > len(clientMsg) {
-		bufLen = len(serverMsg)
-	}
-	buf := make([]byte, bufLen)
-
-	// Client sends a message to the server, which is read by the server.
-	cli.Write([]byte(clientMsg))
-	n, err := srv.Read(buf)
-	if n != len(clientMsg) || string(buf[:n]) != clientMsg {
-		return false, fmt.Errorf("Server read = %d, buf= %q; want %d, %s", n, buf, len(clientMsg), clientMsg)
-	}
-
-	// Server reads a message from the client, which is read by the client.
-	srv.Write([]byte(serverMsg))
-	n, err = cli.Read(buf)
-	if n != len(serverMsg) || err != nil || string(buf[:n]) != serverMsg {
-		return false, fmt.Errorf("Client read = %d, %v, data %q; want %d, nil, %s", n, err, buf, len(serverMsg), serverMsg)
-	}
-
 	// Return true if the client's conn.dc structure was instantiated.
-	return (cli.verifiedDc != nil), nil
+	st := cli.ConnectionState()
+	return (st.DelegatedCredential != nil), nil
 }
 
 // Checks that the client suppports a version >= 1.2 and accepts delegated
@@ -256,7 +239,7 @@ func testServerGetCertificate(ch *ClientHelloInfo) (*Certificate, error) {
 }
 
 // Various test cases for handshakes involving DCs.
-var dcTests = []struct {
+var dcTesters = []struct {
 	clientDC         bool
 	serverDC         bool
 	clientSkipVerify bool
@@ -284,53 +267,46 @@ var dcTests = []struct {
 // Tests the handshake with the delegated credential extension for each test
 // case in dcTests.
 func TestDCHandshake(t *testing.T) {
-	serverMsg := "hello"
-	clientMsg := "world"
-
 	clientConfig := dcTestConfig.Clone()
 	serverConfig := dcTestConfig.Clone()
 	serverConfig.GetCertificate = testServerGetCertificate
 
-	for i, test := range dcTests {
-		clientConfig.MaxVersion = test.clientMaxVers
-		serverConfig.MaxVersion = test.serverMaxVers
-		clientConfig.InsecureSkipVerify = test.clientSkipVerify
-		clientConfig.AcceptDelegatedCredential = test.clientDC
+	for i, tester := range dcTesters {
+		clientConfig.MaxVersion = tester.clientMaxVers
+		serverConfig.MaxVersion = tester.serverMaxVers
+		clientConfig.InsecureSkipVerify = tester.clientSkipVerify
+		clientConfig.AcceptDelegatedCredential = tester.clientDC
 		clientConfig.Time = func() time.Time {
-			return dcTestNow.Add(time.Duration(test.nowOffset))
+			return dcTestNow.Add(time.Duration(tester.nowOffset))
 		}
 
-		if test.serverDC {
+		if tester.serverDC {
 			serverConfig.GetDelegatedCredential = func(
-				ch *ClientHelloInfo, vers uint16) (*DelegatedCredential, crypto.PrivateKey, error) {
-				for _, t := range dcTestDCs {
-					if t.Name == test.dcTestName {
-						dc, err := UnmarshalDelegatedCredential(t.DC)
+				ch *ClientHelloInfo, vers uint16) ([]byte, crypto.PrivateKey, error) {
+				for _, test := range dcTestDCs {
+					if test.Name == tester.dcTestName {
+						sk, err := x509.ParseECPrivateKey(test.PrivateKey)
 						if err != nil {
 							return nil, nil, err
 						}
-						sk, err := x509.ParseECPrivateKey(t.PrivateKey)
-						if err != nil {
-							return nil, nil, err
-						}
-						return dc, sk, nil
+						return test.DC, sk, nil
 					}
 				}
-				return nil, nil, fmt.Errorf("Test DC with name '%s' not found", test.dcTestName)
+				return nil, nil, fmt.Errorf("Test DC with name '%s' not found", tester.dcTestName)
 			}
 		} else {
 			serverConfig.GetDelegatedCredential = nil
 		}
 
-		usedDC, err := testConnWithDC(t, clientMsg, serverMsg, clientConfig, serverConfig)
-		if err != nil && test.expectSuccess {
-			t.Errorf("test #%d (%s) fails: %s", i+1, test.name, err)
-		} else if err == nil && !test.expectSuccess {
-			t.Errorf("test #%d (%s) succeeds; expected failure", i+1, test.name)
+		usedDC, err := testConnWithDC(t, clientConfig, serverConfig)
+		if err != nil && tester.expectSuccess {
+			t.Errorf("test #%d (%s) fails: %s", i+1, tester.name, err)
+		} else if err == nil && !tester.expectSuccess {
+			t.Errorf("test #%d (%s) succeeds; expected failure", i+1, tester.name)
 		}
 
-		if usedDC != test.expectDC {
-			t.Errorf("test #%d (%s) usedDC = %v; expected %v", i+1, test.name, usedDC, test.expectDC)
+		if usedDC != tester.expectDC {
+			t.Errorf("test #%d (%s) usedDC = %v; expected %v", i+1, tester.name, usedDC, tester.expectDC)
 		}
 	}
 }


### PR DESCRIPTION
This removes `NewDelegatedCredential` from the API, as well as the exported `DelegatedCredential` structure.The only dependency on this interface within tris were the tests; it was used to mint DCs for testing the extension in the handshake. These have been replaced with static test data: see `subcerts_test.go`. What's left here are the minimal changes required to be use the DC extension.

The reason for this change is that our needs for the minting API put a lot of pressure on tris. First, it's useful to have the ability to generate a DC key pair, then get the signature with another call. This would have meant changing tris' API. Second, we want to be able to mint DCs that use ed25519. Since ed25519 isn't available in mainline Go, this would have required vendering golang.org/x/crypto/ed25519.  Either of these changes make tris more difficult to maintain, especially if we want to be able to push these changes upstream.

Thus, the minting API, which we'll be consume by goKeyless (github.com/cloudflare.com/gokeylesss), will go elsewhere, perhaps in its own repository.