### PR TITLE
Don't use VersionTLS13DraftXX as public API

### DIFF
--- a/subcerts_test.go
+++ b/subcerts_test.go
@@ -139,7 +139,7 @@ func init() {
 		Rand:         zeroSource{},
 		Certificates: nil,
 		MinVersion:   VersionTLS10,
-		MaxVersion:   VersionTLS13Draft22,
+		MaxVersion:   VersionTLS13,
 		CipherSuites: allCipherSuites(),
 	}
 


### PR DESCRIPTION
Moving to draft-28 break a TestDCHandshake test

```
--- FAIL: TestDCHandshake (0.03s)
	subcerts_test.go:303: test #2 (tls13) fails: delegated credential: signature invalid
	subcerts_test.go:309: test #2 (tls13) usedDC = false; expected true
```