### PR TITLE
 Clients MUST check for supported_versions extensions and abort in case it was received on TLS version prior to 1.3

### DIFF
--- a/handshake_messages.go
+++ b/handshake_messages.go
@@ -1114,7 +1114,11 @@ func (m *serverHelloMsg) unmarshal(data []byte) alert {
 		if m.vers != VersionTLS12 {
 			return alertDecodeError
 		}
-		m.vers = uint16(svData[0])<<8 | uint16(svData[1])
+		rcvVer := binary.BigEndian.Uint16(svData[0:])
+		if rcvVer < VersionTLS13 {
+			return alertIllegalParameter
+		}
+		m.vers = rcvVer
 	}
 
 	for len(data) != 0 {


### PR DESCRIPTION
Fixes #118 