### PR TITLE
removes old draft version indicators

### DIFF
--- a/_dev/tris-localserver/server.go
+++ b/_dev/tris-localserver/server.go
@@ -39,10 +39,6 @@ var tlsVersionToName = map[uint16]string{
 	tls.VersionTLS11:        "1.1",
 	tls.VersionTLS12:        "1.2",
 	tls.VersionTLS13:        "1.3",
-	tls.VersionTLS13Draft18: "1.3 (draft 18)",
-	tls.VersionTLS13Draft21: "1.3 (draft 21)",
-	tls.VersionTLS13Draft22: "1.3 (draft 22)",
-	tls.VersionTLS13Draft23: "1.3 (draft 23)",
 	tls.VersionTLS13Draft28: "1.3 (draft 28)",
 }
 

--- a/_dev/tris-testclient/client.go
+++ b/_dev/tris-testclient/client.go
@@ -16,8 +16,6 @@ var tlsVersionToName = map[uint16]string{
 	tls.VersionTLS11:        "1.1",
 	tls.VersionTLS12:        "1.2",
 	tls.VersionTLS13:        "1.3",
-	tls.VersionTLS13Draft18: "1.3 (draft 18)",
-	tls.VersionTLS13Draft23: "1.3 (draft 23)",
 	tls.VersionTLS13Draft28: "1.3 (draft 28)",
 }
 

--- a/common.go
+++ b/common.go
@@ -27,10 +27,6 @@ const (
 	VersionTLS11        = 0x0302
 	VersionTLS12        = 0x0303
 	VersionTLS13        = 0x0304
-	VersionTLS13Draft18 = 0x7f00 | 18
-	VersionTLS13Draft21 = 0x7f00 | 21
-	VersionTLS13Draft22 = 0x7f00 | 22
-	VersionTLS13Draft23 = 0x7f00 | 23
 	VersionTLS13Draft28 = 0x7f00 | 28
 )
 


### PR DESCRIPTION
```
        VersionTLS11        = 0x0302
        VersionTLS12        = 0x0303
        VersionTLS13        = 0x0304
-       VersionTLS13Draft18 = 0x7f00 | 18
-       VersionTLS13Draft21 = 0x7f00 | 21
-       VersionTLS13Draft22 = 0x7f00 | 22
-       VersionTLS13Draft23 = 0x7f00 | 23
        VersionTLS13Draft28 = 0x7f00 | 28
```