### PR TITLE
cleanup: removes Committer interface

### DIFF
--- a/13.go
+++ b/13.go
@@ -152,12 +152,6 @@ CurvePreferenceLoop:
 		return errors.New("tls: HelloRetryRequest not implemented") // TODO(filippo)
 	}
 
-	if committer, ok := c.conn.(Committer); ok {
-		if err := committer.Commit(); err != nil {
-			return err
-		}
-	}
-
 	privateKey, serverKS, err := config.generateKeyShare(ks.group)
 	if err != nil {
 		c.sendAlert(alertInternalError)

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -16,10 +16,6 @@ import (
 	"sync/atomic"
 )
 
-type Committer interface {
-	Commit() error
-}
-
 // serverHandshakeState contains details of a server handshake in progress.
 // It's discarded once the handshake has completed.
 type serverHandshakeState struct {


### PR DESCRIPTION
I'm removing this interface. I'm only guessing how it could be used, but currently there is no real need for that. Once it becomes needed again - it's in a git history.

Fixes #131 