### PR TITLE
Fix: always store client hello in ConnectionState

### DIFF
--- a/13.go
+++ b/13.go
@@ -234,8 +234,6 @@ func (hs *serverHandshakeState) doTLS13Handshake() error {
 	c := hs.c
 
 	hs.c.cipherSuite, hs.hello.cipherSuite = hs.suite.id, hs.suite.id
-	hs.c.clientHello = hs.clientHello.marshal()
-
 	// When picking the group for the handshake, priority is given to groups
 	// that the client provided a keyShare for, so to avoid a round-trip.
 	// After that the order of CurvePreferences is respected.

--- a/_dev/tris-testclient/client.go
+++ b/_dev/tris-testclient/client.go
@@ -180,7 +180,7 @@ func main() {
 	for _, ng := range strings.Split(named_groups, ":") {
 		id, err := getIDByName(namedGroupsToName, ng)
 		if err != nil {
-			panic("Wrong TLS version provided")
+			panic("Wrong group name provided")
 		}
 		client.TLS.CurvePreferences = append(client.TLS.CurvePreferences, tls.CurveID(id))
 	}

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -65,10 +65,9 @@ func (c *Conn) serverHandshake() error {
 	if err != nil {
 		return err
 	}
-
-	// For an overview of TLS handshaking, see https://tools.ietf.org/html/rfc5246#section-7.3
-	// and https://tools.ietf.org/html/draft-ietf-tls-tls13-18#section-2
+	c.clientHello = hs.clientHello.marshal()
 	c.buffering = true
+
 	if c.vers >= VersionTLS13 {
 		if err := hs.doTLS13Handshake(); err != nil {
 			return err


### PR DESCRIPTION
    Fixes a bug. On a server side, ConnectionState.ClientHello was filled
    only in case server was handling TLSv1.3
