### PR TITLE
Fix macOS build and add it to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
-sudo: required
 language: go
+
+matrix:
+  include:
+    - os: linux
+      env: TEST_SUITE=test-unit
+    - os: linux
+      env: TEST_SUITE=test-bogo
+    - os: linux
+      env: TEST_SUITE=test-interop
+    - os: osx
+      env: TEST_SUITE=test-unit
+  fast_finish: true
 
 services:
   - docker
@@ -7,19 +18,13 @@ services:
 go:
   - 1.11.x
 
-env:
-  - TEST_SUITE=test-unit
-  - TEST_SUITE=test-bogo
-  - TEST_SUITE=test-interop
-
-matrix:
-  fast_finish: true
-
 before_install:
   - make -f _dev/Makefile fmtcheck
 
 install:
-  - sudo pip install docker
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo pip install docker; fi
 
 script:
+  # Travis does not support Docker on macOS, disable it in the build-all target.
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DOCKER='echo Unsupported - docker'; fi
   - make -f _dev/Makefile build-all && make -f _dev/Makefile "$TEST_SUITE"

--- a/_dev/Makefile
+++ b/_dev/Makefile
@@ -46,9 +46,10 @@ $(BUILD_DIR)/$(OS_ARCH)/.ok_$(VER_OS_ARCH): clean
 	mkdir -p "$(GOROOT_LOCAL)/pkg"
 
 # Copy src/tools from system GOROOT
-	cp -Hr $(GOROOT_ENV)/src $(GOROOT_LOCAL)/src
-	cp -Hr $(GOROOT_ENV)/pkg/include $(GOROOT_LOCAL)/pkg/include
-	cp -Hr $(GOROOT_ENV)/pkg/tool $(GOROOT_LOCAL)/pkg/tool
+	# macOS cp requires -R instead of -r. It makes no difference for GNU cp.
+	cp -HR $(GOROOT_ENV)/src $(GOROOT_LOCAL)/src
+	cp -HR $(GOROOT_ENV)/pkg/include $(GOROOT_LOCAL)/pkg/include
+	cp -HR $(GOROOT_ENV)/pkg/tool $(GOROOT_LOCAL)/pkg/tool
 
 # Swap TLS implementation
 	rm -r $(GOROOT_LOCAL)/src/crypto/tls/*
@@ -60,14 +61,16 @@ $(BUILD_DIR)/$(OS_ARCH)/.ok_$(VER_OS_ARCH): clean
 # Vendor NOBS library
 	$(GIT) clone $(NOBS_REPO) $(TMP_DIR)/nobs
 	cd $(TMP_DIR)/nobs; $(GIT) checkout tags/$(NOBS_REPO_TAG)
+	perl -pi -e 's/sed -i/perl -pi -e/' $(TMP_DIR)/nobs/Makefile
 	cd $(TMP_DIR)/nobs; make vendor-sidh-for-tls
-	cp -rf $(TMP_DIR)/nobs/tls_vendor/* $(GOROOT_LOCAL)/src/vendor/
+	cp -rf $(TMP_DIR)/nobs/tls_vendor/. $(GOROOT_LOCAL)/src/vendor/
 
 # Vendor SIDH library
 	$(GIT) clone $(SIDH_REPO) $(TMP_DIR)/sidh
 	cd $(TMP_DIR)/sidh; $(GIT) checkout tags/$(SIDH_REPO_TAG)
+	perl -pi -e 's/sed -i/perl -pi -e/' $(TMP_DIR)/sidh/Makefile
 	cd $(TMP_DIR)/sidh; make vendor
-	cp -rf $(TMP_DIR)/sidh/build/vendor/* $(GOROOT_LOCAL)/src/vendor/
+	cp -rf $(TMP_DIR)/sidh/build/vendor/. $(GOROOT_LOCAL)/src/vendor/
 
 # Create go package
 	GOARCH=$(ARCH) GOROOT="$(GOROOT_LOCAL)" $(GO) install -v std

--- a/_dev/bogo/Dockerfile
+++ b/_dev/bogo/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add --update \
     git \
     make \
     bash \
+    perl \
     patch \
     rsync \
   && rm -rf /var/cache/apk/*


### PR DESCRIPTION
* Options `-r` and `-R` are equivalent for GNU sed, but macOS requires
  `-R' or else it fails with:
  cp: the -H, -L, and -P options may not be specified with the -r option.

* Copying a directory with `-f` on macOS would replace an empty
  directory, resulting in vendor/henrydcase being created instead of
  vendor/github.com/henrydcase. Fix by copying `vendor/.` instead.

* macOS `sed -i` requires an additional argument while that would break
  GNU sed. Use perl instead which has consistent behavior. Once sidn and
  nobs are updated, the workaround can be removed from tris.

* travis: remove deprecated sudo key and add macOS to the test matrix.
___
Partially addresses #165 (it adds macOS support but does not test with different architectures like arm64). Only Go unittests are executed on macOS since Travis lacks support for Docker on macOS.