### PR TITLE
Go 1.12 compatibility fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ os:
 
 go:
   - 1.11.x
+  - 1.12.x
 
 env:
   - TEST_SUITE=test-unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,33 @@
 language: go
 
 matrix:
-  include:
-    - os: linux
-      env: TEST_SUITE=test-unit
-    - os: linux
-      env: TEST_SUITE=test-bogo
-    - os: linux
-      env: TEST_SUITE=test-interop
+  exclude:
     - os: osx
-      env: TEST_SUITE=test-unit
+      env: TEST_SUITE=test-bogo
+    - os: osx
+      env: TEST_SUITE=test-interop
   fast_finish: true
 
 services:
   - docker
 
+os:
+  - linux
+  - osx
+
 go:
   - 1.11.x
+
+env:
+  - TEST_SUITE=test-unit
+  - TEST_SUITE=test-bogo
+  - TEST_SUITE=test-interop
 
 before_install:
   - make -f _dev/Makefile fmtcheck
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo pip install docker; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$TEST_SUITE" != "test-unit" ]]; then sudo pip install docker; fi
 
 script:
   # Travis does not support Docker on macOS, disable it in the build-all target.

--- a/_dev/Makefile
+++ b/_dev/Makefile
@@ -15,6 +15,7 @@ OS          ?= $(shell $(GO) env GOHOSTOS)
 ARCH        ?= $(shell $(GO) env GOHOSTARCH)
 OS_ARCH     := $(OS)_$(ARCH)
 VER_OS_ARCH := $(shell $(GO) version | cut -d' ' -f 3)_$(OS)_$(ARCH)
+VER_MAJOR   := $(shell $(GO) version | cut -d' ' -f 3 | cut -d. -f1-2)
 GOROOT_ENV  ?= $(shell $(GO) env GOROOT)
 GOROOT_LOCAL = $(BUILD_DIR)/$(OS_ARCH)
 # Flag indicates wheter invoke "go install -race std". Supported only on amd64 with CGO enabled
@@ -57,6 +58,11 @@ $(BUILD_DIR)/$(OS_ARCH)/.ok_$(VER_OS_ARCH): clean
 
 # Apply additional patches
 	for p in $(wildcard $(DEV_DIR)/patches/*); do patch -d "$(GOROOT_LOCAL)" -p1 < "$$p"; done
+
+# Adjust internal paths https://github.com/cloudflare/tls-tris/issues/166
+ifeq ($(VER_MAJOR), go1.12)
+	perl -pi -e 's,"golang_org/x/crypto/,"internal/x/crypto/,' $(GOROOT_LOCAL)/src/crypto/tls/*.go
+endif
 
 # Vendor NOBS library
 	$(GIT) clone $(NOBS_REPO) $(TMP_DIR)/nobs

--- a/conn.go
+++ b/conn.go
@@ -641,12 +641,18 @@ type RecordHeaderError struct {
 	// RecordHeader contains the five bytes of TLS record header that
 	// triggered the error.
 	RecordHeader [5]byte
+	// Conn provides the underlying net.Conn in the case that a client
+	// sent an initial handshake that didn't look like TLS.
+	// It is nil if there's already been a handshake or a TLS alert has
+	// been written to the connection.
+	Conn net.Conn
 }
 
 func (e RecordHeaderError) Error() string { return "tls: " + e.Msg }
 
-func (c *Conn) newRecordHeaderError(msg string) (err RecordHeaderError) {
+func (c *Conn) newRecordHeaderError(conn net.Conn, msg string) (err RecordHeaderError) {
 	err.Msg = msg
+	err.Conn = conn
 	copy(err.RecordHeader[:], c.rawInput.data)
 	return err
 }
@@ -702,25 +708,24 @@ Again:
 	// an SSLv2 client.
 	if want == recordTypeHandshake && typ == 0x80 {
 		c.sendAlert(alertProtocolVersion)
-		return c.in.setErrorLocked(c.newRecordHeaderError("unsupported SSLv2 handshake received"))
+		return c.in.setErrorLocked(c.newRecordHeaderError(nil, "unsupported SSLv2 handshake received"))
 	}
 
 	vers := uint16(b.data[1])<<8 | uint16(b.data[2])
 	n := int(b.data[3])<<8 | int(b.data[4])
-	if n > maxCiphertext {
-		c.sendAlert(alertRecordOverflow)
-		msg := fmt.Sprintf("oversized record received with length %d", n)
-		return c.in.setErrorLocked(c.newRecordHeaderError(msg))
-	}
 	if !c.haveVers {
 		// First message, be extra suspicious: this might not be a TLS
 		// client. Bail out before reading a full 'body', if possible.
 		// The current max version is 3.3 so if the version is >= 16.0,
 		// it's probably not real.
 		if (typ != recordTypeAlert && typ != want) || vers >= 0x1000 {
-			c.sendAlert(alertUnexpectedMessage)
-			return c.in.setErrorLocked(c.newRecordHeaderError("first record does not look like a TLS handshake"))
+			return c.in.setErrorLocked(c.newRecordHeaderError(c.conn, "first record does not look like a TLS handshake"))
 		}
+	}
+	if n > maxCiphertext {
+		c.sendAlert(alertRecordOverflow)
+		msg := fmt.Sprintf("oversized record received with length %d", n)
+		return c.in.setErrorLocked(c.newRecordHeaderError(nil, msg))
 	}
 	if err := b.readFromUntil(c.conn, recordHeaderLen+n); err != nil {
 		if err == io.EOF {


### PR DESCRIPTION
Manual port one upstream crypto/tls change in order to provide API compatibility and add Go 1.12 to the compatibility matrix after patching the import paths in _dev/Makefile.

Fixes #166 for Go 1.12 only.
For 1.13, I have another change coming up that might involve import path rewriting.