### PR TITLE
Use standard import paths, preparing for Go modules

### DIFF
--- a/13.go
+++ b/13.go
@@ -21,9 +21,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	sidh "github_com/cloudflare/sidh/sidh"
-	sike "github_com/cloudflare/sidh/sike"
-	"golang_org/x/crypto/curve25519"
+	sidh "github.com/cloudflare/sidh/sidh"
+	sike "github.com/cloudflare/sidh/sike"
+	"golang.org/x/crypto/curve25519"
 )
 
 // numSessionTickets is the number of different session tickets the

--- a/_dev/Makefile
+++ b/_dev/Makefile
@@ -61,8 +61,13 @@ $(BUILD_DIR)/$(OS_ARCH)/.ok_$(VER_OS_ARCH): clean
 
 # Adjust internal paths https://github.com/cloudflare/tls-tris/issues/166
 ifeq ($(VER_MAJOR), go1.12)
-	perl -pi -e 's,"golang_org/x/crypto/,"internal/x/crypto/,' $(GOROOT_LOCAL)/src/crypto/tls/*.go
+	perl -pi -e 's,"golang\.org/x/crypto/,"internal/x/crypto/,' $(GOROOT_LOCAL)/src/crypto/tls/*.go
+else ifeq ($(VER_MAJOR), go1.11)
+	perl -pi -e 's,"golang\.org/x/crypto/,"golang_org/x/crypto/,' $(GOROOT_LOCAL)/src/crypto/tls/*.go
 endif
+	perl -pi -e 's,"golang\.org/x/sys/cpu","internal/cpu",' $(GOROOT_LOCAL)/src/crypto/tls/*.go
+# Use vendored copy of SIDH and SIKE.
+	perl -pi -e 's,"github\.com/,"github_com/,' $(GOROOT_LOCAL)/src/crypto/tls/*.go
 
 # Vendor NOBS library
 	$(GIT) clone $(NOBS_REPO) $(TMP_DIR)/nobs

--- a/cipher_suites.go
+++ b/cipher_suites.go
@@ -15,7 +15,7 @@ import (
 	"crypto/sha256"
 	"hash"
 
-	"golang_org/x/crypto/chacha20poly1305"
+	"golang.org/x/crypto/chacha20poly1305"
 )
 
 // a keyAgreement implements the client and server side of a TLS key agreement

--- a/common.go
+++ b/common.go
@@ -12,13 +12,14 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"internal/cpu"
 	"io"
 	"math/big"
 	"net"
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/sys/cpu"
 )
 
 const (

--- a/key_agreement.go
+++ b/key_agreement.go
@@ -14,7 +14,7 @@ import (
 	"io"
 	"math/big"
 
-	"golang_org/x/crypto/curve25519"
+	"golang.org/x/crypto/curve25519"
 )
 
 var errClientKeyExchange = errors.New("tls: invalid ClientKeyExchange message")


### PR DESCRIPTION
Change import paths to use standard import paths, this is friendlier to
standard tooling like syntax checking. Additionally, `go mod vendor` and
`go get` now works without a custom Go compiler. Such import paths will
also be needed for Go 1.13.

Note that `go test` passes except for example_test.go which fails due to
importing crypto/tls instead of tris. Likewise for programs in _dev/.

When building with _dev/go.sh, it will still patch the import paths to
use internal import paths though. This is the default and won't change.
___
Partially addresses #158 by making it importable by default.