### PR TITLE
interop_test_runner: use Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: go
 
 matrix:
@@ -28,7 +29,10 @@ before_install:
   - make -f _dev/Makefile fmtcheck
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$TEST_SUITE" != "test-unit" ]]; then sudo pip install docker; fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$TEST_SUITE" != "test-unit" ]]; then
+      sudo apt-get install -y python3-pip && sudo pip3 install docker
+    fi
 
 script:
   # Travis does not support Docker on macOS, disable it in the build-all target.

--- a/_dev/Makefile
+++ b/_dev/Makefile
@@ -135,7 +135,7 @@ test-bogo:
 	$(DOCKER) run --rm -v $(PRJ_DIR):$(BOGO_DOCKER_TRIS_LOCATION) tls-tris:bogo
 
 test-interop:
-	$(DEV_DIR)/interop_test_runner -v
+	$(DEV_DIR)/interop_test_runner.py -v
 
 ###############
 #


### PR DESCRIPTION
'python2' does not exist on macOS, it is called 'python2.7'. Porting to
Python 3 is however more future-proof so do that instead. Rename the
file such that it can be run with pytest.

Do not listen on a fixed host port and use a random port instead.
Otherwise tests could fail if something is listening on those ports.
___
~~Note, with this modification, I noticed some ResourceWarnings after calling `exec_run` due to a Docker socket being leaked. These won't affect the test results though so I just left it there. See https://github.com/docker/docker-py/issues/1293#issuecomment-486250527~~ I removed the wait logic improvement due to the complexity and the fact that it triggers a bug in docker-py.

I upgraded to Xenial to ensure a newer python3-six version to solve a failure importing docker. https://github.com/docker/docker-py/issues/2294#issuecomment-486269556

With the file rename, I can now do run a subset of the tests during development:

    pytest _dev/interop_test_runner.py -k SIDH -v

and add `-nauto` to run those tests in parallel (requires `pytest-xdist`). This can complete all tests in 30 seconds (with 12 jobs). Another nice feature is the ability to pause when an assertion fails and inspect the context:

    pytest _dev/interop_test_runner.py -k 'test_SIDH and Server'  --pdb