### PR TITLE
Remove dependency on tls.Conn in key agreement abstraction

### DIFF
--- a/handshake_client.go
+++ b/handshake_client.go
@@ -194,7 +194,7 @@ func (c *Conn) clientHandshake() error {
 		// Create one keyshare for the first default curve. If it is not
 		// appropriate, the server should raise a HRR.
 		defaultGroup := c.config.curvePreferences()[0]
-		hs.privateKey, clientKS, err = c.generateKeyShare(defaultGroup)
+		hs.privateKey, clientKS, err = generateKeyShare(c.isClient, c.config.rand(), defaultGroup)
 		if err != nil {
 			c.sendAlert(alertInternalError)
 			return err


### PR DESCRIPTION
The key agreement protocols only need a source of randomness for key
generation and agreement (for KEM), and the role (client or server), so
pass these explicitly.

Make keyAgreementClient and keyAgreementServer independent of the
tls.Conn instance to allow reuse for ESNI.
___
In the TLS handshake, we have:
1. Client generates an ephemeral private key and sends a derived public key share.
2. Server takes this public key share, generates a new ephemeral private key, derives a shared secret and sends a derived public key share.
3. Client uses its earlier private key to compute the same shared secret.

For ESNI, we have:
1. Server generates a semi-static private key and publishes a derived public key share (say, in DNS).
2. Client generates a new ephemeral private key, derives a shared secret and sends a derived public key share.
3. Server uses its earlier private key to compute the shared secret.

As you can see the roles are reversed. It didn't seem correct to call keyAgreementClient as a server and vice versa. Neither am I sure if the "Alice" and "Bob" role should be reversed for SIDH. For ESNI I plan to support ECDHE only. ~~The `ecdheKex` interface is adapted for the TLS handshake (with PQ support), but for ESNI, this interface will directly be used.~~ The kex interface is maintained, instead keyAgreementXxx have been made independent of Conn. For ESNI I simply do not use the PQ algorithms, so the difference between keyAgreementClient/Server does not matter.

~~It is possible to specialize the "generate" method, for TLS it could receive "isClient" but in ECDHE there is no distinction so I could drop it. Thoughts?~~ 