### PR TITLE
tls_test: remove TestVerifyHostnameResumed

### DIFF
--- a/tls_test.go
+++ b/tls_test.go
@@ -353,33 +353,6 @@ func TestVerifyHostname(t *testing.T) {
 	}
 }
 
-func TestVerifyHostnameResumed(t *testing.T) {
-	config := &Config{
-		ClientSessionCache: NewLRUClientSessionCache(32),
-		// There is no "New ticket" sent in case TLS v1.3 is advertised.
-		// Hence forcing TLSv12
-		MaxVersion: VersionTLS12,
-	}
-
-	for i := 0; i < 2; i++ {
-		c, err := Dial("tcp", "www.google.com:https", config)
-		if err != nil {
-			t.Fatalf("Dial #%d: %v", i, err)
-		}
-		cs := c.ConnectionState()
-		if i > 0 && !cs.DidResume {
-			t.Fatalf("Subsequent connection unexpectedly didn't resume")
-		}
-		if cs.VerifiedChains == nil {
-			t.Fatalf("Dial #%d: cs.VerifiedChains == nil", i)
-		}
-		if err := c.VerifyHostname("www.google.com"); err != nil {
-			t.Fatalf("verify www.google.com #%d: %v", i, err)
-		}
-		c.Close()
-	}
-}
-
 func TestConnCloseBreakingWrite(t *testing.T) {
 	ln := newLocalListener(t)
 	defer ln.Close()


### PR DESCRIPTION
This is already removed upstream in 20e4540e9084 ("crypto/tls: remove
TestVerifyHostnameResumed") and addresses failing tests in Travis.
___
Not a clean backport due to other upstream changes to this test:
- golang/go@30cc9780856b5a88ca2a8f05312758077ca48ba1 crypto/tls: enable TLS 1.3 and update tests
- golang/go@e22e2b371d5caa4144de1eedc8484def68f9d4d9 crypto/tls: fix TestVerifyHostnameResumed
- golang/go@20e4540e9084528a1b36978882596daa7d8d8800 crypto/tls: remove TestVerifyHostnameResumed