### PR TITLE
Fix shell scripts: Double quote to prevent globbing and word splitting.

### DIFF
--- a/_dev/go.sh
+++ b/_dev/go.sh
@@ -6,7 +6,7 @@ set -e
 BASEDIR=$(cd "$(dirname "$0")" && pwd)
 GOENV="$(go env GOHOSTOS)_$(go env GOHOSTARCH)"
 
-BUILD_DIR=${BASEDIR}/GOROOT make -f $BASEDIR/Makefile >&2
+BUILD_DIR=${BASEDIR}/GOROOT make -f "$BASEDIR"/Makefile >&2
 
 export GOROOT="$BASEDIR/GOROOT/$GOENV"
 exec go "$@"

--- a/_dev/picotls/run.sh
+++ b/_dev/picotls/run.sh
@@ -6,5 +6,5 @@ shift
 HOST="${ADDR[0]}"
 PORT="${ADDR[1]}"
 
-/picotls/cli -s /session -e "$@" $HOST $PORT < /httpreq.txt
-/picotls/cli -s /session -e "$@" $HOST $PORT < /httpreq.txt
+/picotls/cli -s /session -e "$@" "$HOST" "$PORT" < /httpreq.txt
+/picotls/cli -s /session -e "$@" "$HOST" "$PORT" < /httpreq.txt

--- a/_dev/tstclnt/run.sh
+++ b/_dev/tstclnt/run.sh
@@ -5,4 +5,4 @@ shift
 HOST="${ADDR[0]}"
 PORT="${ADDR[1]}"
 
-exec /dist/OBJ-PATH/bin/tstclnt -D -V tls1.3:tls1.3 -o -O -h $HOST -p $PORT -v -A /httpreq.txt -L 2 -Z "$@"
+exec /dist/OBJ-PATH/bin/tstclnt -D -V tls1.3:tls1.3 -o -O -h "$HOST" -p "$PORT" -v -A /httpreq.txt -L 2 -Z "$@"

--- a/_dev/utils/fmtcheck.sh
+++ b/_dev/utils/fmtcheck.sh
@@ -6,7 +6,7 @@
 gofiles=$(find . -iname "*.go" ! -path "*/_dev/*")
 #[ -z "$gofiles" ] && exit 0
 
-unformatted=$(gofmt -l $gofiles)
+unformatted=$(gofmt -l "$gofiles")
 [ -z "$unformatted" ] && exit 0
 
 # Some files are not gofmt'd. Print message and fail.

--- a/_dev/utils/pre-commit
+++ b/_dev/utils/pre-commit
@@ -13,7 +13,7 @@
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
 [ -z "$gofiles" ] && exit 0
 
-unformatted=$(gofmt -l $gofiles)
+unformatted=$(gofmt -l "$gofiles")
 [ -z "$unformatted" ] && exit 0
 
 # Some files are not gofmt'd. Print message and fail.


### PR DESCRIPTION
Checked with ShellCheck.

https://www.shellcheck.net/

https://github.com/koalaman/shellcheck/wiki/SC2086